### PR TITLE
[KED-917] Add CachedDataSet which caches data in memory to avoid io

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,3 +20,5 @@ README.md                               @idanov
 RELEASE.md                              @idanov
 LICENSE.md                              @idanov
 legal_header.txt                        @idanov
+
+kedro/contrib/io/cached                 @tsanikgr

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,9 @@ Improved API docs
 ## Breaking changes to the API
 
 
+## Contrib
+- CachedDataSet which cached data in memory to avoid io/network operations (@tsanikgr)
+
 # Release 0.14.0:
 
 The initial release of Kedro.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,9 @@ from pathlib import Path
 from typing import List, Tuple
 
 from click import secho, style
+from recommonmark.transform import AutoStructify
 
 from kedro import __version__ as release
-from recommonmark.transform import AutoStructify
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/source/05_api_docs/kedro.contrib.io.rst
+++ b/docs/source/05_api_docs/kedro.contrib.io.rst
@@ -23,3 +23,4 @@ kedro.contrib.io
       kedro.contrib.io.bioinformatics.BioSequenceLocalDataSet
       kedro.contrib.io.pyspark.SparkDataSet
       kedro.contrib.io.pyspark.SparkJDBCDataSet
+      kedro.contrib.io.cached.CachedDataSet

--- a/kedro/contrib/io/cached/__init__.py
+++ b/kedro/contrib/io/cached/__init__.py
@@ -1,0 +1,34 @@
+# Copyright 2018-2019 QuantumBlack Visual Analytics Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+# NONINFRINGEMENT. IN NO EVENT WILL THE LICENSOR OR OTHER CONTRIBUTORS
+# BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF, OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# The QuantumBlack Visual Analytics Limited (“QuantumBlack”) name and logo
+# (either separately or in combination, “QuantumBlack Trademarks”) are
+# trademarks of QuantumBlack. The License does not grant you any right or
+# license to the QuantumBlack Trademarks. You may not use the QuantumBlack
+# Trademarks or any confusingly similar mark as a trademark for your product,
+#     or use the QuantumBlack Trademarks in any other manner that might cause
+# confusion in the marketplace, including but not limited to in advertising,
+# on websites, or on software.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains ``CachedDataSet``, a dataset wrapper which caches in memory the data saved,
+so that the user avoids io operations with slow storage media
+"""
+
+from .cached import CachedDataSet  # NOQA

--- a/kedro/contrib/io/cached/cached.py
+++ b/kedro/contrib/io/cached/cached.py
@@ -31,7 +31,7 @@ This module contains ``CachedDataSet``, a dataset wrapper which caches in memory
 so that the user avoids io operations with slow storage media
 """
 import pickle
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 from kedro.io import (
     AbstractDataSet,
@@ -62,7 +62,10 @@ class CachedDataSet(AbstractDataSet, ExistsMixin, FilepathVersionMixIn):
     """
 
     def __init__(
-        self, dataset: AbstractDataSet, max_loads: int = None, version: Version = None
+        self,
+        dataset: Union[AbstractDataSet, Dict],
+        max_loads: int = None,
+        version: Version = None,
     ):
         super().__init__()
         if isinstance(dataset, Dict):

--- a/kedro/contrib/io/cached/cached.py
+++ b/kedro/contrib/io/cached/cached.py
@@ -74,7 +74,7 @@ class CachedDataSet(AbstractDataSet, ExistsMixin, FilepathVersionMixIn):
             self._dataset = dataset
         else:
             raise ValueError(
-                "The argument type of `dataset` should be either a dict/YML "
+                "The argument type of `dataset` should be either a dict/YAML "
                 "representation of the dataset, or the actual dataset object."
             )
         self._cache = MemoryDataSet(max_loads=max_loads)
@@ -121,5 +121,5 @@ class CachedDataSet(AbstractDataSet, ExistsMixin, FilepathVersionMixIn):
         # in the future this can be made pickleable by erasing the cache.
         # A slight challenge would be to see how to propagate max_loads
         raise pickle.PicklingError(
-            "{}: `CachedDataSet`s cannot be " r"serialised".format(str(self))
+            "{}: `CachedDataSet`s cannot be serialised".format(str(self))
         )

--- a/kedro/contrib/io/cached/cached.py
+++ b/kedro/contrib/io/cached/cached.py
@@ -69,7 +69,7 @@ class CachedDataSet(AbstractDataSet, ExistsMixin, FilepathVersionMixIn):
     ):
         super().__init__()
         if isinstance(dataset, Dict):
-            self._dataset = self._from_config(dataset, version or Version(None, None))
+            self._dataset = self._from_config(dataset, version)
         elif isinstance(dataset, AbstractDataSet):
             self._dataset = dataset
         else:
@@ -87,8 +87,9 @@ class CachedDataSet(AbstractDataSet, ExistsMixin, FilepathVersionMixIn):
                 "`CachedDataSet`, not in the wrapped dataset."
             )
         if version:
-            config[VERSIONED_FLAG_KEY] = version
-        return AbstractDataSet.from_config("Cached", config, version.load, version.save)
+            config[VERSIONED_FLAG_KEY] = True
+            return AbstractDataSet.from_config("Cached", config, version.load, version.save)
+        return AbstractDataSet.from_config("Cached", config)
 
     def _describe(self) -> Dict[str, Any]:
         return {

--- a/kedro/contrib/io/cached/cached.py
+++ b/kedro/contrib/io/cached/cached.py
@@ -1,0 +1,121 @@
+# Copyright 2018-2019 QuantumBlack Visual Analytics Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+# NONINFRINGEMENT. IN NO EVENT WILL THE LICENSOR OR OTHER CONTRIBUTORS
+# BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF, OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# The QuantumBlack Visual Analytics Limited (“QuantumBlack”) name and logo
+# (either separately or in combination, “QuantumBlack Trademarks”) are
+# trademarks of QuantumBlack. The License does not grant you any right or
+# license to the QuantumBlack Trademarks. You may not use the QuantumBlack
+# Trademarks or any confusingly similar mark as a trademark for your product,
+#     or use the QuantumBlack Trademarks in any other manner that might cause
+# confusion in the marketplace, including but not limited to in advertising,
+# on websites, or on software.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains ``CachedDataSet``, a dataset wrapper which caches in memory the data saved,
+so that the user avoids io operations with slow storage media
+"""
+import pickle
+from typing import Any, Dict
+
+from kedro.io import (
+    AbstractDataSet,
+    ExistsMixin,
+    FilepathVersionMixIn,
+    MemoryDataSet,
+    Version,
+)
+from kedro.io.core import VERSIONED_FLAG_KEY
+
+
+class CachedDataSet(AbstractDataSet, ExistsMixin, FilepathVersionMixIn):
+    """
+    ``CachedDataSet`` is a dataset wrapper which caches in memory the data saved, so that the
+    user avoids io operations with slow storage media.
+
+    You can also specify ``CachedDataSet``s in catalog.yml as follows:
+    ::
+      test_ds:
+          type: kedro.contrib.io.cached.CachedDataSet
+          versioned: true
+          dataset:
+              type: CSVLocalDataSet
+              filepath: example.csv
+
+    Please notice that if your dataset is versioned, this should be indicated in the wrapper class
+    as shown above
+    """
+
+    def __init__(
+        self, dataset: AbstractDataSet, max_loads: int = None, version: Version = None
+    ):
+        super().__init__()
+        if isinstance(dataset, Dict):
+            self._dataset = self._from_config(dataset, version or Version(None, None))
+        elif isinstance(dataset, AbstractDataSet):
+            self._dataset = dataset
+        else:
+            raise ValueError(
+                "The argument type of `dataset` should be either a dict/YML "
+                "representation of the dataset, or the actual dataset object."
+            )
+        self._cache = MemoryDataSet(max_loads=max_loads)
+
+    @staticmethod
+    def _from_config(config, version):
+        if VERSIONED_FLAG_KEY in config:
+            raise ValueError(
+                "Cached datasets should specify that they are versioned in the "
+                "`CachedDataSet`, not in the wrapped dataset."
+            )
+        if version:
+            config[VERSIONED_FLAG_KEY] = version
+        return AbstractDataSet.from_config("Cached", config, version.load, version.save)
+
+    def _describe(self) -> Dict[str, Any]:
+        return {
+            "dataset": self._dataset._describe(),  # pylint: disable=protected-access
+            "cache": self._cache._describe(),  # pylint: disable=protected-access
+        }
+
+    def _load(self):
+        if self._cache.exists():
+            return self._cache.load()
+
+        data = self._dataset.load()
+        self._cache.save(data)
+        return data
+
+    def _save(self, data: Any) -> None:
+        self._dataset.save(data)
+        self._cache.save(data)
+
+    def _exists(self) -> bool:
+        def _wrapped_exists():
+            if hasattr(self._dataset, "exists"):
+                return self._dataset.exists()
+            return False  # pragma: no cover
+
+        return self._cache.exists() or _wrapped_exists()
+
+    def __getstate__(self):
+        # in the future this can be made pickleable by erasing the cache.
+        # A slight challenge would be to see how to propagate max_loads
+        raise pickle.PicklingError(
+            "{}: `CachedDataSet`s cannot be " r"serialised".format(str(self))
+        )

--- a/tests/contrib/io/cached/test_cached_dataset.py
+++ b/tests/contrib/io/cached/test_cached_dataset.py
@@ -1,0 +1,160 @@
+# Copyright 2018-2019 QuantumBlack Visual Analytics Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+# NONINFRINGEMENT. IN NO EVENT WILL THE LICENSOR OR OTHER CONTRIBUTORS
+# BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF, OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# The QuantumBlack Visual Analytics Limited (“QuantumBlack”) name and logo
+# (either separately or in combination, “QuantumBlack Trademarks”) are
+# trademarks of QuantumBlack. The License does not grant you any right or
+# license to the QuantumBlack Trademarks. You may not use the QuantumBlack
+# Trademarks or any confusingly similar mark as a trademark for your product,
+#     or use the QuantumBlack Trademarks in any other manner that might cause
+# confusion in the marketplace, including but not limited to in advertising,
+# on websites, or on software.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# pylint: disable=protected-access
+import pickle
+from io import StringIO
+from pickle import PicklingError
+
+import pytest
+import yaml
+
+from kedro.contrib.io.cached import CachedDataSet
+from kedro.io import CSVLocalDataSet, DataCatalog, DataSetError, MemoryDataSet
+
+YML_CONFIG = """
+test_ds:
+  type: kedro.contrib.io.cached.CachedDataSet
+  dataset:
+      type: CSVLocalDataSet
+      filepath: example.csv
+"""
+
+YML_CONFIG_VERSIONED = """
+test_ds:
+  type: kedro.contrib.io.cached.CachedDataSet
+  versioned: true
+  dataset:
+      type: CSVLocalDataSet
+      filepath: example.csv
+"""
+
+YML_CONFIG_VERSIONED_BAD = """
+test_ds:
+  type: kedro.contrib.io.cached.CachedDataSet
+  dataset:
+      type: CSVLocalDataSet
+      filepath: example.csv
+      versioned: true
+"""
+
+
+@pytest.fixture
+def cached_ds():
+    wrapped = MemoryDataSet()
+    return CachedDataSet(wrapped)
+
+
+class TestCachedDataset:
+    def test_load_empty(self, cached_ds):
+        with pytest.raises(DataSetError, match=r"has not been saved yet"):
+            _ = cached_ds.load()
+
+    def test_save_load(self, cached_ds):
+        cached_ds.save(42)
+        assert cached_ds.load() == 42
+
+    def test_save_load_caching(self, mocker):
+        wrapped = MemoryDataSet(-42)
+        mocker.spy(wrapped, "load")
+        mocker.spy(wrapped, "save")
+
+        cached_ds = CachedDataSet(wrapped)
+        mocker.spy(cached_ds._cache, "save")
+        mocker.spy(cached_ds._cache, "load")
+
+        cached_ds.save(42)
+        assert cached_ds.load() == 42
+        assert wrapped.load.call_count == 0
+        assert wrapped.save.call_count == 1
+        assert cached_ds._cache.load.call_count == 1
+        assert cached_ds._cache.save.call_count == 1
+
+    def test_load_empty_cache(self, mocker):
+        wrapped = MemoryDataSet(-42)
+        mocker.spy(wrapped, "load")
+
+        cached_ds = CachedDataSet(wrapped)
+        mocker.spy(cached_ds._cache, "load")
+
+        assert cached_ds.load() == -42
+        assert wrapped.load.call_count == 1
+        assert cached_ds._cache.load.call_count == 0
+
+    def test_from_yaml(self, mocker):
+        config = yaml.safe_load(StringIO(YML_CONFIG))
+        catalog = DataCatalog.from_config(config)
+        assert catalog.list() == ["test_ds"]
+        mock = mocker.Mock()
+        assert isinstance(catalog._data_sets["test_ds"]._dataset, CSVLocalDataSet)
+        catalog._data_sets["test_ds"]._dataset = mock
+        catalog.save("test_ds", 20)
+
+        assert catalog.load("test_ds") == 20
+        mock.save.assert_called_once_with(20)
+        mock.load.assert_not_called()
+
+    def test_bad_argument(self):
+        with pytest.raises(
+            ValueError,
+            match=r"The argument type of `dataset` "
+            r"should be either a dict/YML representation "
+            r"of the dataset, or the actual dataset object",
+        ):
+            _ = CachedDataSet(dataset="BadArgument")
+
+    def test_config_good_version(self):
+        config = yaml.safe_load(StringIO(YML_CONFIG_VERSIONED))
+        catalog = DataCatalog.from_config(config, load_versions={"test_ds": "42"})
+        assert catalog._data_sets["test_ds"]._dataset._version.load == "42"
+
+    def test_config_bad_version(self):
+        config = yaml.safe_load(StringIO(YML_CONFIG_VERSIONED_BAD))
+        with pytest.raises(
+            DataSetError,
+            match=r"Cached datasets should specify that they are "
+            r"versioned in the `CachedDataSet`, not in the "
+            r"wrapped dataset",
+        ):
+            _ = DataCatalog.from_config(config, load_versions={"test_ds": "42"})
+
+    def test_exists(self, cached_ds):
+        assert not cached_ds.exists()
+        cached_ds.save(42)
+        assert cached_ds.exists()
+
+    def test_pickle(self, cached_ds):
+        with pytest.raises(
+            PicklingError, match=r"CachedDataSet.*`CachedDataSet`s cannot be serialised"
+        ):
+            _ = pickle.dumps(cached_ds)
+
+    def test_str(self):
+        assert (
+            str(CachedDataSet(MemoryDataSet(42))) == "CachedDataSet(cache={}, "
+            "dataset={'data': <int>})"
+        )


### PR DESCRIPTION
## Notice

- [x] I acknowledge and agree that, by checking this box and clicking “Submit Pull Request”:
 
- I submit this contribution under the Apache 2.0 license available [here](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees. 
- I certify that this contribution does not violate the intellectual property rights of anyone else.
 
## Motivation and Context
In many cases, users want to save a dataset to disk/some other filesystem (like Amazon's S3 etc), but want to re-use the dataset in nodes downstream of their pipeline. In these cases, the dataset keeps being reloaded from disk/network for every node in which it is needed.

`CachedDataSet` is an `AbstractDataSet` wrapper which will cache in memory the data the first time it is loaded/saved. Subsequent calls to `.load()` will return the data from memory, and subsequent calls to `.save()` will overwrite both the data on disk/network and the cache.

## How has this been tested?
Unit tests

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
