### PR TITLE
Refactor how max_loads is set for MemoryDataSets

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,7 +5,7 @@ Improved API docs
 
 
 ## Bug fixes and other changes
-
+Any custom `AbstractDataSet` may now specify the maximum number of times it can be loaded using `set_max_loads()`
 
 ## Breaking changes to the API
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,7 +5,7 @@ Improved API docs
 
 
 ## Bug fixes and other changes
-Any custom `AbstractDataSet` may now specify the maximum number of times it can be loaded using `set_max_loads()`
+Any custom `AbstractDataSet` may now implement how to restrict the maximum number of times it can be loaded using `set_max_loads()`
 
 ## Breaking changes to the API
 

--- a/kedro/cli/cli.py
+++ b/kedro/cli/cli.py
@@ -30,7 +30,6 @@
 
 This module implements commands available from the kedro CLI.
 """
-# pylint: disable=missing-param-doc,missing-type-doc,missing-return-doc,missing-return-type-doc
 import glob
 import importlib
 import os

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -290,6 +290,18 @@ class AbstractDataSet(abc.ABC):
             "it must implement the `_describe` method".format(self.__class__.__name__)
         )
 
+    def set_max_loads(self, max_loads: int):
+        """Set how many times this dataset can be loaded. ``DataSet``s that can set a limit to
+        the number of times they can be loaded need to implement this method and the relevant
+        logic.
+
+        Args:
+            max_loads: Maximum number of times ``load`` method of the
+                data set is allowed to be invoked. Any number of calls
+                is allowed if the argument is not set.
+        """
+        pass
+
 
 class ExistsMixin(abc.ABC):
     """Mixin class which provides an exists() method."""

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -45,7 +45,6 @@ from kedro.utils import load_obj
 MAX_DESCRIPTION_LENGTH = 70
 VERSIONED_FLAG_KEY = "versioned"
 VERSION_KEY = "version"
-FORCE_UNLIMITED_LOADS = -1
 
 
 class DataSetError(Exception):
@@ -291,11 +290,10 @@ class AbstractDataSet(abc.ABC):
             "it must implement the `_describe` method".format(self.__class__.__name__)
         )
 
-    def set_max_loads(self, max_loads: int = FORCE_UNLIMITED_LOADS):
+    def set_max_loads(self, max_loads: int):
         """Set how many times this dataset can be loaded. ``DataSet``s that can set a limit to
         the number of times they can be loaded need to implement this method and the relevant
-        logic, or the can specify that they can be loaded unlimited times by using
-        ``kedro.io.core.FORCE_UNLIMITED_LOADS``
+        logic.
 
         Args:
             max_loads: Maximum number of times ``load`` method of the

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -45,6 +45,7 @@ from kedro.utils import load_obj
 MAX_DESCRIPTION_LENGTH = 70
 VERSIONED_FLAG_KEY = "versioned"
 VERSION_KEY = "version"
+FORCE_UNLIMITED_LOADS = -1
 
 
 class DataSetError(Exception):
@@ -290,10 +291,11 @@ class AbstractDataSet(abc.ABC):
             "it must implement the `_describe` method".format(self.__class__.__name__)
         )
 
-    def set_max_loads(self, max_loads: int):
+    def set_max_loads(self, max_loads: int = FORCE_UNLIMITED_LOADS):
         """Set how many times this dataset can be loaded. ``DataSet``s that can set a limit to
         the number of times they can be loaded need to implement this method and the relevant
-        logic.
+        logic, or the can specify that they can be loaded unlimited times by using
+        ``kedro.io.core.FORCE_UNLIMITED_LOADS``
 
         Args:
             max_loads: Maximum number of times ``load`` method of the

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -444,7 +444,7 @@ class DataCatalog:
         return self._data_sets == other._data_sets  # pylint: disable=protected-access
 
     def set_max_loads(self, ds_name: str, max_loads: int):
-        """Set the maximum number of times this dataset can be loaded. ``DataSet``s like
+        """Set the maximum number of times the given dataset can be loaded. ``DataSet``s like
         ``MemoryDataSet`` use this to clear data from memory. In most other cases, this has no
         effect.
 

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -442,3 +442,16 @@ class DataCatalog:
 
     def __eq__(self, other):
         return self._data_sets == other._data_sets  # pylint: disable=protected-access
+
+    def set_max_loads(self, ds_name: str, max_loads: int):
+        """Set the maximum number of times this dataset can be loaded. ``DataSet``s like
+        ``MemoryDataSet`` use this to clear data from memory. In most other cases, this has no
+        effect.
+
+        Args:
+            ds_name: The dataset to modify
+            max_loads: Maximum number of times ``load`` method of the
+                data set is allowed to be invoked. Any number of calls
+                is allowed if the argument is not set.
+        """
+        self._data_sets[ds_name].set_max_loads(max_loads)

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -446,8 +446,7 @@ class DataCatalog:
     def set_max_loads(self, ds_name: str, max_loads: int):
         """Set the maximum number of times the given dataset can be loaded. ``DataSet``s like
         ``MemoryDataSet`` use this to clear data from memory. In most other cases, this has no
-        effect. Dataset implementations can specify that they can be loaded unlimited times by
-        using ``kedro.io.core.FORCE_UNLIMITED_LOADS``
+        effect.
 
         Args:
             ds_name: The dataset to modify

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -446,7 +446,8 @@ class DataCatalog:
     def set_max_loads(self, ds_name: str, max_loads: int):
         """Set the maximum number of times the given dataset can be loaded. ``DataSet``s like
         ``MemoryDataSet`` use this to clear data from memory. In most other cases, this has no
-        effect.
+        effect. Dataset implementations can specify that they can be loaded unlimited times by
+        using ``kedro.io.core.FORCE_UNLIMITED_LOADS``
 
         Args:
             ds_name: The dataset to modify

--- a/kedro/io/memory_data_set.py
+++ b/kedro/io/memory_data_set.py
@@ -121,3 +121,6 @@ class MemoryDataSet(AbstractDataSet, ExistsMixin):
         if self._data is None:
             return False
         return True
+
+    def set_max_loads(self, max_loads):
+        self._max_loads = max_loads

--- a/kedro/runner/parallel_runner.py
+++ b/kedro/runner/parallel_runner.py
@@ -75,7 +75,7 @@ class ParallelRunner(AbstractRunner):
 
         """
         # pylint: disable=no-member
-        return self._manager.MemoryDataSet()
+        return self._manager.MemoryDataSet(max_loads=0)
 
     @classmethod
     def _validate_nodes(cls, nodes: Iterable[Node]):

--- a/kedro/runner/parallel_runner.py
+++ b/kedro/runner/parallel_runner.py
@@ -63,14 +63,11 @@ class ParallelRunner(AbstractRunner):
         self._manager = ParallelRunnerManager()
         self._manager.start()
 
-    def create_default_data_set(self, ds_name: str, max_loads: int) -> AbstractDataSet:
+    def create_default_data_set(self, ds_name: str) -> AbstractDataSet:
         """Factory method for creating the default data set for the runner.
 
         Args:
             ds_name: Name of the missing data set
-            max_loads: Maximum number of times ``load`` method of the
-                default data set is allowed to be invoked. Any number of
-                calls is allowed if the argument is not set.
 
         Returns:
             An instance of an implementation of AbstractDataSet to be used
@@ -78,7 +75,7 @@ class ParallelRunner(AbstractRunner):
 
         """
         # pylint: disable=no-member
-        return self._manager.MemoryDataSet(max_loads=max_loads)
+        return self._manager.MemoryDataSet()
 
     @classmethod
     def _validate_nodes(cls, nodes: Iterable[Node]):

--- a/kedro/runner/parallel_runner.py
+++ b/kedro/runner/parallel_runner.py
@@ -75,7 +75,7 @@ class ParallelRunner(AbstractRunner):
 
         """
         # pylint: disable=no-member
-        return self._manager.MemoryDataSet(max_loads=0)
+        return self._manager.MemoryDataSet()
 
     @classmethod
     def _validate_nodes(cls, nodes: Iterable[Node]):

--- a/kedro/runner/runner.py
+++ b/kedro/runner/runner.py
@@ -77,9 +77,12 @@ class AbstractRunner(ABC):
         free_outputs = pipeline.outputs() - set(catalog.list())
         unregistered_ds = pipeline.data_sets() - set(catalog.list())
         for ds_name in unregistered_ds:
+            catalog.add(ds_name, self.create_default_data_set(ds_name))
+
+        for ds_name in catalog.list():
             num_loads = len(pipeline.only_nodes_with_inputs(ds_name).nodes)
             num_loads = num_loads if num_loads > 0 else None
-            catalog.add(ds_name, self.create_default_data_set(ds_name, num_loads))
+            catalog.set_max_loads(ds_name, num_loads)
 
         self._run(pipeline, catalog)
 
@@ -135,14 +138,11 @@ class AbstractRunner(ABC):
         pass
 
     @abstractmethod  # pragma: no cover
-    def create_default_data_set(self, ds_name: str, max_loads: int) -> AbstractDataSet:
+    def create_default_data_set(self, ds_name: str) -> AbstractDataSet:
         """Factory method for creating the default data set for the runner.
 
         Args:
             ds_name: Name of the missing data set
-            max_loads: Maximum number of times ``load`` method of the
-                default data set is allowed to be invoked. Any number of
-                calls is allowed if the argument is not set.
 
         Returns:
             An instance of an implementation of AbstractDataSet to be

--- a/kedro/runner/runner.py
+++ b/kedro/runner/runner.py
@@ -81,8 +81,8 @@ class AbstractRunner(ABC):
 
         for ds_name in catalog.list():
             num_loads = len(pipeline.only_nodes_with_inputs(ds_name).nodes)
-            num_loads = num_loads if num_loads > 0 else None
-            catalog.set_max_loads(ds_name, num_loads)
+            if num_loads > 0:
+                catalog.set_max_loads(ds_name, num_loads)
 
         self._run(pipeline, catalog)
 

--- a/kedro/runner/runner.py
+++ b/kedro/runner/runner.py
@@ -80,9 +80,10 @@ class AbstractRunner(ABC):
             catalog.add(ds_name, self.create_default_data_set(ds_name))
 
         for ds_name in catalog.list():
-            num_loads = len(pipeline.only_nodes_with_inputs(ds_name).nodes)
-            if num_loads > 0:
-                catalog.set_max_loads(ds_name, num_loads)
+            if ds_name in pipeline.data_sets():
+                num_loads = len(pipeline.only_nodes_with_inputs(ds_name).nodes)
+                if num_loads > 0:
+                    catalog.set_max_loads(ds_name, num_loads)
 
         self._run(pipeline, catalog)
 

--- a/kedro/runner/sequential_runner.py
+++ b/kedro/runner/sequential_runner.py
@@ -52,7 +52,7 @@ class SequentialRunner(AbstractRunner):
             for all unregistered data sets.
 
         """
-        return MemoryDataSet(max_loads=0)
+        return MemoryDataSet()
 
     def _run(self, pipeline: Pipeline, catalog: DataCatalog) -> None:
         """The method implementing sequential pipeline running.

--- a/kedro/runner/sequential_runner.py
+++ b/kedro/runner/sequential_runner.py
@@ -52,7 +52,7 @@ class SequentialRunner(AbstractRunner):
             for all unregistered data sets.
 
         """
-        return MemoryDataSet()
+        return MemoryDataSet(max_loads=0)
 
     def _run(self, pipeline: Pipeline, catalog: DataCatalog) -> None:
         """The method implementing sequential pipeline running.

--- a/kedro/runner/sequential_runner.py
+++ b/kedro/runner/sequential_runner.py
@@ -41,21 +41,18 @@ class SequentialRunner(AbstractRunner):
     topological sort of provided nodes.
     """
 
-    def create_default_data_set(self, ds_name: str, max_loads: int) -> AbstractDataSet:
+    def create_default_data_set(self, ds_name: str) -> AbstractDataSet:
         """Factory method for creating the default data set for the runner.
 
         Args:
             ds_name: Name of the missing data set
-            max_loads: Maximum number of times ``load`` method of the
-                default data set is allowed to be invoked. Any number of
-                calls is allowed if the argument is not set.
 
         Returns:
             An instance of an implementation of AbstractDataSet to be used
             for all unregistered data sets.
 
         """
-        return MemoryDataSet(max_loads=max_loads)
+        return MemoryDataSet()
 
     def _run(self, pipeline: Pipeline, catalog: DataCatalog) -> None:
         """The method implementing sequential pipeline running.

--- a/tests/io/test_memory_data_set.py
+++ b/tests/io/test_memory_data_set.py
@@ -161,7 +161,7 @@ class TestMemoryDataSet:
 
 
 class TestMemoryDataSetMaxLoads:
-    @pytest.mark.parametrize("max_loads", [None, -1, 0, 1, 2], indirect=True)
+    @pytest.mark.parametrize("max_loads", [-1, 0, 1, 2], indirect=True)
     def test_max_loads(self, memory_data_set_loads, input_data, max_loads):
         """Test that the first load succeeds regardless of the maximum number
         of loads specified"""
@@ -196,3 +196,10 @@ class TestMemoryDataSetMaxLoads:
         memory_data_set_loads.save(input_data)
         loaded_data = memory_data_set_loads.load()
         assert _check_equals(loaded_data, input_data)
+
+    def test_max_loads_zero(self, memory_data_set):
+        with pytest.raises(
+            ValueError,
+            match=r"Setting max_loads to zero " r"for `MemoryDataSet` is not allowed",
+        ):
+            memory_data_set.set_max_loads(0)

--- a/tests/io/test_memory_data_set.py
+++ b/tests/io/test_memory_data_set.py
@@ -161,7 +161,7 @@ class TestMemoryDataSet:
 
 
 class TestMemoryDataSetMaxLoads:
-    @pytest.mark.parametrize("max_loads", [-1, 0, 1, 2], indirect=True)
+    @pytest.mark.parametrize("max_loads", [None, -1, 0, 1, 2], indirect=True)
     def test_max_loads(self, memory_data_set_loads, input_data, max_loads):
         """Test that the first load succeeds regardless of the maximum number
         of loads specified"""
@@ -196,10 +196,3 @@ class TestMemoryDataSetMaxLoads:
         memory_data_set_loads.save(input_data)
         loaded_data = memory_data_set_loads.load()
         assert _check_equals(loaded_data, input_data)
-
-    def test_max_loads_zero(self, memory_data_set):
-        with pytest.raises(
-            ValueError,
-            match=r"Setting max_loads to zero " r"for `MemoryDataSet` is not allowed",
-        ):
-            memory_data_set.set_max_loads(0)

--- a/tests/runner/test_parallel_runner.py
+++ b/tests/runner/test_parallel_runner.py
@@ -74,7 +74,7 @@ def fan_out_fan_in():
 class TestValidParallelRunner:
     def test_create_default_data_set(self):
         # data_set is a proxy to a dataset in another process.
-        data_set = ParallelRunner().create_default_data_set("", 0)
+        data_set = ParallelRunner().create_default_data_set("")
         assert isinstance(data_set, BaseProxy)
 
     def test_parallel_run(self, fan_out_fan_in, catalog):


### PR DESCRIPTION
This change allows the custom implementation of `AbstractDataSet`s that
can set a limit on the number of times something can be loaded. For
example, a `CachedDataSet` might want to clear its cache after the data
has been loaded a certain number of times

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking “Submit Pull Request”:
 
- I submit this contribution under the Apache 2.0 license available [here](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees. 
- I certify that this contribution does not violate the intellectual property rights of anyone else.
 
## Motivation and Context
This change allows the custom implementation of `AbstractDataSet`s that can set a limit on the number of times something can be loaded. For example, a `CachedDataSet` might want to clear its cache after the data has been loaded a certain number of times

As a result, I believe this change makes the code more extensible. To achieve the same effect now, one needs to create a custom `Runner`, which is probably too much work.

Possibly this needs to be deprecated in the future and moved to be a built-in functionality of datasets (like `versioned`).

## How has this been tested?
Existing unit tests - no API breaking changes

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
