### PR TITLE
Minor documentation fix for kedro new cli command

### DIFF
--- a/kedro/cli/cli.py
+++ b/kedro/cli/cli.py
@@ -120,12 +120,12 @@ def new(config):
 
     \b
     You will have to provide four choices:
-    * ``Output Directory`` - parent directory where new project directory
-    should be created.
     * ``Project Name`` - name of the project, not to be confused with name of
     the project folder.
     * ``Repository Name`` - intended name of your project folder.
     * ``Package Name`` - intended name of your Python package.
+    * ``Generate Example Pipeline`` - yes/no to generating an example pipeline
+    in your project.
 
     \b
     ``kedro new --config <config.yml>``
@@ -133,8 +133,9 @@ def new(config):
     Create a new project from configuration.
 
     * ``config.yml`` - The configuration YAML must contain at the top level
-                    the above parameters (output_dir, project_name, repo_name,
-                    python_package).
+                    the above parameters (project_name, repo_name,
+                    python_package, include_example) and output_dir - the
+                    parent directory for the new project directory.
     """
     _create_project(config, _KEDRO_CONTEXT["verbose"])
 


### PR DESCRIPTION
Minor correction regarding the information that kedro new and kedro new -c requires: kedro new doesn't ask for output_dir, but does ask for include_example and kedro new -c requires all 5 params in the docstring of `new` in `kedro.cli`.

The [public readthedocs](https://kedro.readthedocs.io/en/latest/02_getting_started/03_new_project.html#create-a-new-project-interactively) documentation is fine, so this really is very minor - feel free to dismiss it! 😄 

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking “Submit Pull Request”:

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
Figured I might as well!

## How has this been tested?
N/A

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Assigned myself to the PR
- [ ] Added `Type` label to the PR