### PR TITLE
Make PEP 561 compatible packages :sparkling_heart:

### DIFF
--- a/kedro/py.typed
+++ b/kedro/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.  The kedro package uses inline types.

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,8 @@ setup(
     install_requires=requires,
     author="QuantumBlack Labs",
     entry_points={"console_scripts": ["kedro = kedro.cli:main"]},
-    package_data={name: template_files + doc_html_files},
+    package_data={name: ["py.typed"] + template_files + doc_html_files},
+    zip_safe=False,
     keywords="pipelines, machine learning, data pipelines, data science, data engineering",
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
Distributing and packaging type information as per PEP 561 makes type checkers like mypy aware that the third-party package (in this case, Kedro) supports typing, and the importing package can then perform (Kedro-)typing-aware checking. The best alternative is to push stubs to typeshed, but that doesn't take full advantage of inline typing and is maintained by a different team.

## How has this been tested?
What testing strategies have you used?

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Assigned myself to the PR
