### PR TITLE
Add only_missing option in KedroContext class 

### DIFF
--- a/kedro/context/context.py
+++ b/kedro/context/context.py
@@ -226,7 +226,8 @@ class KedroContext(abc.ABC):
         catalog.add_feed_dict(self._get_feed_dict())
         return catalog
 
-    def run(self, tags: Iterable[str] = None, runner: AbstractRunner = None, only_missing: bool = False) -> None:
+    def run(self, tags: Iterable[str] = None, runner: AbstractRunner = None,
+            only_missing: bool = False) -> None:
         """Runs the pipeline with a specified runner.
 
         Args:

--- a/kedro/context/context.py
+++ b/kedro/context/context.py
@@ -226,7 +226,7 @@ class KedroContext(abc.ABC):
         catalog.add_feed_dict(self._get_feed_dict())
         return catalog
 
-    def run(self, tags: Iterable[str] = None, runner: AbstractRunner = None) -> None:
+    def run(self, tags: Iterable[str] = None, runner: AbstractRunner = None, only_missing: bool = False) -> None:
         """Runs the pipeline with a specified runner.
 
         Args:
@@ -235,6 +235,7 @@ class KedroContext(abc.ABC):
                 containing *any* of these tags will be added to the ``Pipeline``.
             runner: An optional parameter specifying the runner that you want to run
                 the pipeline with.
+            only_missing: An option to run only missing nodes.
         Raises:
             KedroContextError: If the resulting ``Pipeline`` is empty
                 or incorrect tags are provided.
@@ -253,7 +254,10 @@ class KedroContext(abc.ABC):
 
         # Run the runner
         runner = runner or SequentialRunner()
-        runner.run(pipeline, self.catalog)
+        if only_missing:
+            runner.run_only_missing(pipeline, self.catalog)
+        else:
+            runner.run(pipeline, self.catalog)
 
 
 def load_context(project_path: Union[str, Path], **kwargs) -> KedroContext:


### PR DESCRIPTION
## Notice

- [ x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
`run_only_missing` option was missing in `KedroContext` class introduced by `[KED-826] Use KedroContext class in project template (#111)`

## How has this been tested?
1. Run `kedro new` and create a new kedro project including the iris data pipeline.
2. Modify `context.run(tags, runner)` to `context.run(tags, runner, only_missing=True)` in `run.py`
![image](https://user-images.githubusercontent.com/33908456/61480158-ecec3580-a9c7-11e9-9155-3c083433e34e.png)
3. Run `kedro run` and confirm the 4 tasks are processed by the logged message.
4. Run `kedro run` again and confirm the 4 tasks are not processed again because of the `only_missing` option. 

![image](https://user-images.githubusercontent.com/33908456/61480797-57ea3c00-a9c9-11e9-965e-3c68d1cd7a3a.png)


## Checklist

- [x ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Assigned myself to the PR
