### PR TITLE
Only check import format in ``kedro lint`` command

### DIFF
--- a/docs/source/06_resources/03_lint.md
+++ b/docs/source/06_resources/03_lint.md
@@ -19,7 +19,7 @@ Alternatively, you can opt to use it as a plugin to your Kedro project. To do th
 @cli.command()
 def lint():
     """Check the Python code quality."""
-    python_call("isort", [])
+    python_call("isort", ["-rc", "src/<your_project>", "src/tests", "kedro_cli.py"])
     python_call(
         "pylint", ["-j", "0", "src/<your_project>", "kedro_cli.py"]
     )


### PR DESCRIPTION
## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
Why was this PR created?

If you run `kedro lint` as part of Circle CI (for example), you want to check that the style is OK, not make changes. `isort` should be run locally or as a pre-commit hook, but CI should just check that everything is good.

## How has this been tested?
What testing strategies have you used?

Use on Cotopaxi, etc.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added new entries to the `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Assigned myself to the PR
