### PR TITLE
Return the output datasets

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 ## Major features and improvements
 * Added a new CLI command `kedro jupyter convert` to facilitate converting Jupyter notebook cells into Kedro nodes.
-* Added `KedroContext` base class which holds the configuration and Kedro's main functionality (catalog, pipeline, config).
+* Added `KedroContext` base class which holds the configuration and Kedro's main functionality (catalog, pipeline, config, runner).
 * Added a new I/O module `ParquetS3DataSet` in `contrib` for usage with Pandas. (by [@mmchougule](https://github.com/mmchougule))
 * Added a new `--node` flag to `kedro run`, allowing users to run only the nodes with the specified names.
 * Added `CSVHTTPDataSet` to load CSV using HTTP(s) links.

--- a/kedro/context/context.py
+++ b/kedro/context/context.py
@@ -234,7 +234,7 @@ class KedroContext(abc.ABC):
         node_names: Iterable[str] = None,
         from_nodes: Iterable[str] = None,
         to_nodes: Iterable[str] = None,
-    ) -> None:
+    ) -> Dict[str, Any]:
         """Runs the pipeline with a specified runner.
 
         Args:
@@ -253,7 +253,10 @@ class KedroContext(abc.ABC):
         Raises:
             KedroContextError: If the resulting ``Pipeline`` is empty
                 or incorrect tags are provided.
-
+        Returns:
+            Any node outputs that cannot be processed by the ``DataCatalog``.
+            These are returned in a dictionary, where the keys are defined
+            by the node outputs.
         """
         # Report project name
         logging.info("** Kedro project {}".format(self.project_path.name))
@@ -278,7 +281,7 @@ class KedroContext(abc.ABC):
 
         # Run the runner
         runner = runner or SequentialRunner()
-        runner.run(pipeline, self.catalog)
+        return runner.run(pipeline, self.catalog)
 
 
 def load_context(project_path: Union[str, Path], **kwargs) -> KedroContext:

--- a/tests/context/test_context.py
+++ b/tests/context/test_context.py
@@ -281,59 +281,65 @@ class TestKedroContext:
 class TestKedroContextRun:
     def test_default_run(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
-        dummy_context.run()
+        outputs = dummy_context.run()
 
         log_msgs = [record.getMessage() for record in caplog.records]
         log_names = [record.name for record in caplog.records]
 
         assert "kedro.runner.sequential_runner" in log_names
         assert "Pipeline execution completed successfully." in log_msgs
+        pd.testing.assert_frame_equal(outputs['planes'], dummy_dataframe)
 
     def test_sequential_run_arg(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
-        dummy_context.run(runner=SequentialRunner())
+        outputs = dummy_context.run(runner=SequentialRunner())
 
         log_msgs = [record.getMessage() for record in caplog.records]
         log_names = [record.name for record in caplog.records]
         assert "kedro.runner.sequential_runner" in log_names
         assert "Pipeline execution completed successfully." in log_msgs
+        pd.testing.assert_frame_equal(outputs['planes'], dummy_dataframe)
 
     def test_parallel_run_arg(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
-        dummy_context.run(runner=ParallelRunner())
+        outputs = dummy_context.run(runner=ParallelRunner())
 
         log_msgs = [record.getMessage() for record in caplog.records]
         log_names = [record.name for record in caplog.records]
         assert "kedro.runner.parallel_runner" in log_names
         assert "Pipeline execution completed successfully." in log_msgs
+        pd.testing.assert_frame_equal(outputs['planes'], dummy_dataframe)
 
     def test_run_with_node_names(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
-        dummy_context.run(node_names=["node1"])
+        outputs = dummy_context.run(node_names=["node1"])
 
         log_msgs = [record.getMessage() for record in caplog.records]
         assert "Running node: node1: identity([cars]) -> [boats]" in log_msgs
         assert "Pipeline execution completed successfully." in log_msgs
         assert "Running node: node2: identity([boats]) -> [trains]" not in log_msgs
+        assert not bool(outputs)
 
     def test_run_with_node_names_and_tags(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
-        dummy_context.run(node_names=["node1"], tags=["tag1", "pipeline"])
+        outputs = dummy_context.run(node_names=["node1"], tags=["tag1", "pipeline"])
 
         log_msgs = [record.getMessage() for record in caplog.records]
         assert "Running node: node1: identity([cars]) -> [boats]" in log_msgs
         assert "Pipeline execution completed successfully." in log_msgs
         assert "Running node: node2: identity([boats]) -> [trains]" not in log_msgs
+        assert not bool(outputs)
 
     def test_run_with_tags(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
-        dummy_context.run(tags=["tag1"])
+        outputs = dummy_context.run(tags=["tag1"])
         log_msgs = [record.getMessage() for record in caplog.records]
 
         assert "Completed 1 out of 1 tasks" in log_msgs
         assert "Running node: node1: identity([cars]) -> [boats]" in log_msgs
         assert "Running node: node2: identity([boats]) -> [trains]" not in log_msgs
         assert "Pipeline execution completed successfully." in log_msgs
+        assert not bool(outputs)
 
     def test_run_with_wrong_tags(self, dummy_context, dummy_dataframe):
         dummy_context.catalog.save("cars", dummy_dataframe)
@@ -343,16 +349,17 @@ class TestKedroContextRun:
 
     def test_run_from_nodes(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
-        dummy_context.run(from_nodes=["node1"])
+        outputs = dummy_context.run(from_nodes=["node1"])
 
         log_msgs = [record.getMessage() for record in caplog.records]
         assert "Completed 4 out of 4 tasks" in log_msgs
         assert "Running node: node1: identity([cars]) -> [boats]" in log_msgs
         assert "Pipeline execution completed successfully." in log_msgs
+        pd.testing.assert_frame_equal(outputs['planes'], dummy_dataframe)
 
     def test_run_to_nodes(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
-        dummy_context.run(to_nodes=["node2"])
+        outputs = dummy_context.run(to_nodes=["node2"])
 
         log_msgs = [record.getMessage() for record in caplog.records]
         assert "Completed 2 out of 2 tasks" in log_msgs
@@ -360,10 +367,11 @@ class TestKedroContextRun:
         assert "Running node: node2: identity([boats]) -> [trains]" in log_msgs
         assert "Running node: node3: identity([trains]) -> [ships]" not in log_msgs
         assert "Pipeline execution completed successfully." in log_msgs
+        assert not bool(outputs)
 
     def test_run_with_node_range(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
-        dummy_context.run(from_nodes=["node1"], to_nodes=["node3"])
+        outputs = dummy_context.run(from_nodes=["node1"], to_nodes=["node3"])
 
         log_msgs = [record.getMessage() for record in caplog.records]
         assert "Completed 3 out of 3 tasks" in log_msgs
@@ -371,6 +379,7 @@ class TestKedroContextRun:
         assert "Running node: node2: identity([boats]) -> [trains]" in log_msgs
         assert "Running node: node3: identity([trains]) -> [ships]" in log_msgs
         assert "Pipeline execution completed successfully." in log_msgs
+        pd.testing.assert_frame_equal(outputs['ships'], dummy_dataframe)
 
     def test_run_with_invalid_node_range(self, dummy_context, dummy_dataframe):
         dummy_context.catalog.save("cars", dummy_dataframe)

--- a/tests/context/test_context.py
+++ b/tests/context/test_context.py
@@ -318,7 +318,7 @@ class TestKedroContextRun:
         assert "Running node: node1: identity([cars]) -> [boats]" in log_msgs
         assert "Pipeline execution completed successfully." in log_msgs
         assert "Running node: node2: identity([boats]) -> [trains]" not in log_msgs
-        assert not bool(outputs)
+        assert not outputs
 
     def test_run_with_node_names_and_tags(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
@@ -328,7 +328,7 @@ class TestKedroContextRun:
         assert "Running node: node1: identity([cars]) -> [boats]" in log_msgs
         assert "Pipeline execution completed successfully." in log_msgs
         assert "Running node: node2: identity([boats]) -> [trains]" not in log_msgs
-        assert not bool(outputs)
+        assert not outputs
 
     def test_run_with_tags(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
@@ -339,7 +339,7 @@ class TestKedroContextRun:
         assert "Running node: node1: identity([cars]) -> [boats]" in log_msgs
         assert "Running node: node2: identity([boats]) -> [trains]" not in log_msgs
         assert "Pipeline execution completed successfully." in log_msgs
-        assert not bool(outputs)
+        assert not outputs
 
     def test_run_with_wrong_tags(self, dummy_context, dummy_dataframe):
         dummy_context.catalog.save("cars", dummy_dataframe)
@@ -367,7 +367,7 @@ class TestKedroContextRun:
         assert "Running node: node2: identity([boats]) -> [trains]" in log_msgs
         assert "Running node: node3: identity([trains]) -> [ships]" not in log_msgs
         assert "Pipeline execution completed successfully." in log_msgs
-        assert not bool(outputs)
+        assert not outputs
 
     def test_run_with_node_range(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)

--- a/tests/context/test_context.py
+++ b/tests/context/test_context.py
@@ -279,67 +279,71 @@ class TestKedroContext:
 
 @pytest.mark.usefixtures("config_dir")
 class TestKedroContextRun:
-    def test_default_run(self, dummy_context, dummy_dataframe, caplog):
+    def test_run_output(self, dummy_context, dummy_dataframe):
         dummy_context.catalog.save("cars", dummy_dataframe)
         outputs = dummy_context.run()
+        pd.testing.assert_frame_equal(outputs['planes'], dummy_dataframe)
+
+    def test_run_no_output(self, dummy_context, dummy_dataframe):
+        dummy_context.catalog.save("cars", dummy_dataframe)
+        outputs = dummy_context.run(node_names=["node1"])
+        assert not outputs
+
+    def test_default_run(self, dummy_context, dummy_dataframe, caplog):
+        dummy_context.catalog.save("cars", dummy_dataframe)
+        dummy_context.run()
 
         log_msgs = [record.getMessage() for record in caplog.records]
         log_names = [record.name for record in caplog.records]
 
         assert "kedro.runner.sequential_runner" in log_names
         assert "Pipeline execution completed successfully." in log_msgs
-        pd.testing.assert_frame_equal(outputs['planes'], dummy_dataframe)
 
     def test_sequential_run_arg(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
-        outputs = dummy_context.run(runner=SequentialRunner())
+        dummy_context.run(runner=SequentialRunner())
 
         log_msgs = [record.getMessage() for record in caplog.records]
         log_names = [record.name for record in caplog.records]
         assert "kedro.runner.sequential_runner" in log_names
         assert "Pipeline execution completed successfully." in log_msgs
-        pd.testing.assert_frame_equal(outputs['planes'], dummy_dataframe)
 
     def test_parallel_run_arg(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
-        outputs = dummy_context.run(runner=ParallelRunner())
+        dummy_context.run(runner=ParallelRunner())
 
         log_msgs = [record.getMessage() for record in caplog.records]
         log_names = [record.name for record in caplog.records]
         assert "kedro.runner.parallel_runner" in log_names
         assert "Pipeline execution completed successfully." in log_msgs
-        pd.testing.assert_frame_equal(outputs['planes'], dummy_dataframe)
 
     def test_run_with_node_names(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
-        outputs = dummy_context.run(node_names=["node1"])
+        dummy_context.run(node_names=["node1"])
 
         log_msgs = [record.getMessage() for record in caplog.records]
         assert "Running node: node1: identity([cars]) -> [boats]" in log_msgs
         assert "Pipeline execution completed successfully." in log_msgs
         assert "Running node: node2: identity([boats]) -> [trains]" not in log_msgs
-        assert not outputs
 
     def test_run_with_node_names_and_tags(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
-        outputs = dummy_context.run(node_names=["node1"], tags=["tag1", "pipeline"])
+        dummy_context.run(node_names=["node1"], tags=["tag1", "pipeline"])
 
         log_msgs = [record.getMessage() for record in caplog.records]
         assert "Running node: node1: identity([cars]) -> [boats]" in log_msgs
         assert "Pipeline execution completed successfully." in log_msgs
         assert "Running node: node2: identity([boats]) -> [trains]" not in log_msgs
-        assert not outputs
 
     def test_run_with_tags(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
-        outputs = dummy_context.run(tags=["tag1"])
+        dummy_context.run(tags=["tag1"])
         log_msgs = [record.getMessage() for record in caplog.records]
 
         assert "Completed 1 out of 1 tasks" in log_msgs
         assert "Running node: node1: identity([cars]) -> [boats]" in log_msgs
         assert "Running node: node2: identity([boats]) -> [trains]" not in log_msgs
         assert "Pipeline execution completed successfully." in log_msgs
-        assert not outputs
 
     def test_run_with_wrong_tags(self, dummy_context, dummy_dataframe):
         dummy_context.catalog.save("cars", dummy_dataframe)
@@ -349,17 +353,16 @@ class TestKedroContextRun:
 
     def test_run_from_nodes(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
-        outputs = dummy_context.run(from_nodes=["node1"])
+        dummy_context.run(from_nodes=["node1"])
 
         log_msgs = [record.getMessage() for record in caplog.records]
         assert "Completed 4 out of 4 tasks" in log_msgs
         assert "Running node: node1: identity([cars]) -> [boats]" in log_msgs
         assert "Pipeline execution completed successfully." in log_msgs
-        pd.testing.assert_frame_equal(outputs['planes'], dummy_dataframe)
 
     def test_run_to_nodes(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
-        outputs = dummy_context.run(to_nodes=["node2"])
+        dummy_context.run(to_nodes=["node2"])
 
         log_msgs = [record.getMessage() for record in caplog.records]
         assert "Completed 2 out of 2 tasks" in log_msgs
@@ -367,11 +370,10 @@ class TestKedroContextRun:
         assert "Running node: node2: identity([boats]) -> [trains]" in log_msgs
         assert "Running node: node3: identity([trains]) -> [ships]" not in log_msgs
         assert "Pipeline execution completed successfully." in log_msgs
-        assert not outputs
 
     def test_run_with_node_range(self, dummy_context, dummy_dataframe, caplog):
         dummy_context.catalog.save("cars", dummy_dataframe)
-        outputs = dummy_context.run(from_nodes=["node1"], to_nodes=["node3"])
+        dummy_context.run(from_nodes=["node1"], to_nodes=["node3"])
 
         log_msgs = [record.getMessage() for record in caplog.records]
         assert "Completed 3 out of 3 tasks" in log_msgs
@@ -379,7 +381,6 @@ class TestKedroContextRun:
         assert "Running node: node2: identity([boats]) -> [trains]" in log_msgs
         assert "Running node: node3: identity([trains]) -> [ships]" in log_msgs
         assert "Pipeline execution completed successfully." in log_msgs
-        pd.testing.assert_frame_equal(outputs['ships'], dummy_dataframe)
 
     def test_run_with_invalid_node_range(self, dummy_context, dummy_dataframe):
         dummy_context.catalog.save("cars", dummy_dataframe)


### PR DESCRIPTION
## Notice

- [x ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
`KedroContext.run` does not return the output datasets returned by `runner.run`.
Note: this PR replaces https://github.com/quantumblacklabs/kedro/pull/62 which has conflicts.

## How has this been tested?
Test code was added and run.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added new entries to the `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Assigned myself to the PR
