### PR TITLE
Remove assert_called_once in tests

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -182,7 +182,7 @@ class TestCliCommands:
         for each in ("Opening file", join("html", "index.html")):
             assert each in result.output
 
-        patched_browser.assert_called_once_with()
+        assert patched_browser.call_count == 1
         args, _ = patched_browser.call_args
         for each in ("file://", join("kedro", "html", "index.html")):
             assert each in args[0]

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -182,7 +182,7 @@ class TestCliCommands:
         for each in ("Opening file", join("html", "index.html")):
             assert each in result.output
 
-        patched_browser.assert_called_once()
+        patched_browser.assert_called_once_with()
         args, _ = patched_browser.call_args
         for each in ("file://", join("kedro", "html", "index.html")):
             assert each in args[0]


### PR DESCRIPTION
cf https://github.com/PyCQA/pycodestyle/issues/624 👨‍💻

Don't think this is worth adding myself to `RELEASE.md`, feel free to merge/close. 🎸 

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
Using `assert_called_once` isn't recommended, especially when supporting Python 3.5, since it doesn't exist, but because the object is mocked, no error is raised.

## How has this been tested?
🤖

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](/RELEASE.md) file
- [x] Added tests to cover my changes
- [ ] Assigned myself to the PR
