### PR TITLE
Fix ParquetGCSDataSet that had wrongly passed a PosixPath into gcsfs.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,12 +5,14 @@
 
 ## Bug fixes and other changes
 
+* * Fixed a bug in the `invalidate_cache` method of `ParquetGCSDataSet` and `CSVGCSDataSet`.
 
 ## Breaking changes to the API
 
 
 ## Thanks for supporting contributions
 
+[Jonas Kemper](https://github.com/jonasrk)
 
 # Release 0.15.5
 

--- a/kedro/contrib/io/gcs/csv_gcs.py
+++ b/kedro/contrib/io/gcs/csv_gcs.py
@@ -153,4 +153,5 @@ class CSVGCSDataSet(DefaultArgumentsMixIn, AbstractVersionedDataSet):
 
     def invalidate_cache(self) -> None:
         """Invalidate underlying filesystem caches."""
-        self._gcs.invalidate_cache(self._filepath)
+        # gcsfs expects a string as filepath. It will crash with PosixPath.
+        self._gcs.invalidate_cache(str(self._filepath))

--- a/kedro/contrib/io/gcs/parquet_gcs.py
+++ b/kedro/contrib/io/gcs/parquet_gcs.py
@@ -156,4 +156,5 @@ class ParquetGCSDataSet(DefaultArgumentsMixIn, AbstractVersionedDataSet):
 
     def invalidate_cache(self) -> None:
         """Invalidate underlying filesystem caches."""
-        self._gcs.invalidate_cache(self._filepath)
+        # gcsfs expects a string as filepath. It will crash with PosixPath.
+        self._gcs.invalidate_cache(str(self._filepath))


### PR DESCRIPTION
# 1  Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context

Resolves #187 .

Please note:

- The link to contributing guidelines below is dead.
- I can't seem to assign myself to the PR.

The ParquetGCSDataSet dataset in contrib is now passing a string path into gcsfs.GCSFileSystem()'s .invalidate_cache() . ParquetGCSDataSet has been introduced in the recent Kedro 0.15.5 release ( https://github.com/quantumblacklabs/kedro/blob/develop/RELEASE.md ). I suppose no one noticed that invalidate_cache takes a string ( https://github.com/dask/gcsfs/blob/master/gcsfs/core.py#L730 ).

If you try to pass a PosixPath, it will crash with:

'PurePosixPath' object has no attribute 'startswith'

kedro.io.core.DataSetError: Failed while saving data to data set ParquetGCSDataSet

File "/usr/local/anaconda3/envs/v36/lib/python3.6/site-packages/kedro/contrib/io/gcs/parquet_gcs.py", line 159, in invalidate_cache
    self._gcs.invalidate_cache(self._filepath)

## How has this been tested?
-

## Checklist

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Assigned myself to the PR
