### PR TITLE
Fix bug in to_nodes and from_nodes for pipeline with transcoding

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,13 +19,15 @@
 * Enabled running `node`s with duplicate inputs.
 * Fixed bug that caused an empty project to fail unexpectedly with ImportError in `template/.../pipeline.py`
 * Fixed bug related to saving dataframe with categorical variables in table mode using HDFS3DataSet.
+* Fixed bug that caused unexpected behavior when using `from_nodes` and `to_nodes` in pipelines using transcoding.
 
 ## Breaking changes to the API
 * Existing `MatplotlibWriter` dataset in `contrib` was renamed to `MatplotlibLocalWriter`.
 * `kedro/contrib/io/matplotlib/matplotlib_writer.py` was renamed to `kedro/contrib/io/matplotlib/matplotlib_local_writer.py`.
 
 ## Thanks for supporting contributions
-[Jonas Kemper](https://github.com/jonasrk), [Yuhao Zhu](https://github.com/yhzqb), [Balazs Konig](https://github.com/BalazsKonigQB)
+[Jonas Kemper](https://github.com/jonasrk), [Yuhao Zhu](https://github.com/yhzqb), [Balazs Konig](https://github.com/BalazsKonigQB), [Pedro Abreu](https://github.com/PedroAbreuQB)
+
 # Release 0.15.5
 
 ## Major features and improvements

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -673,7 +673,7 @@ class Pipeline:
         """
 
         res = self.only_nodes(*node_names)
-        res += self.from_inputs(*res.all_outputs())
+        res += self.from_inputs(*map(_get_transcode_compatible_name, res.all_outputs()))
         return res
 
     def to_nodes(self, *node_names: str) -> "Pipeline":
@@ -694,7 +694,7 @@ class Pipeline:
         """
 
         res = self.only_nodes(*node_names)
-        res += self.to_outputs(*res.all_inputs())
+        res += self.to_outputs(*map(_get_transcode_compatible_name, res.all_inputs()))
         return res
 
     def only_nodes_with_tags(self, *tags: str) -> "Pipeline":

--- a/tests/pipeline/test_pipeline_with_transcoding.py
+++ b/tests/pipeline/test_pipeline_with_transcoding.py
@@ -274,12 +274,13 @@ class TestComplexPipelineWithTranscoding:
 
     """
 
-    def test_from_to_nodes_transcoded_names(self, complex_pipeline):
-        """New pipelines contain all nodes that depend on node8, node7."""
+    # pylint: disable=too-many-public-methods
+
+    def test_from_nodes_transcoded_names(self, complex_pipeline):
+        """New pipelines contain all nodes that depend on node8 downstream."""
         from_nodes_pipeline = complex_pipeline.from_nodes("node8")
         nodes = {node.name for node in from_nodes_pipeline.nodes}
 
-        assert len(from_nodes_pipeline.nodes) == 9
         assert nodes == {
             "node1",
             "node2",
@@ -292,10 +293,11 @@ class TestComplexPipelineWithTranscoding:
             "node10",
         }
 
+    def test_to_nodes_transcoded_names(self, complex_pipeline):
+        """New pipelines contain all nodes that depend on node7 upstream."""
         to_nodes_pipeline = complex_pipeline.to_nodes("node7")
         nodes = {node.name for node in to_nodes_pipeline.nodes}
 
-        assert len(to_nodes_pipeline.nodes) == 3
         assert nodes == {"node7", "node8", "node9"}
 
     def test_only_nodes_with_inputs(self, complex_pipeline):

--- a/tests/pipeline/test_pipeline_with_transcoding.py
+++ b/tests/pipeline/test_pipeline_with_transcoding.py
@@ -274,6 +274,30 @@ class TestComplexPipelineWithTranscoding:
 
     """
 
+    def test_from_to_nodes_transcoded_names(self, complex_pipeline):
+        """New pipelines contain all nodes that depend on node8, node7."""
+        from_nodes_pipeline = complex_pipeline.from_nodes("node8")
+        nodes = {node.name for node in from_nodes_pipeline.nodes}
+
+        assert len(from_nodes_pipeline.nodes) == 9
+        assert nodes == {
+            "node1",
+            "node2",
+            "node3",
+            "node4",
+            "node5",
+            "node6",
+            "node7",
+            "node8",
+            "node10",
+        }
+
+        to_nodes_pipeline = complex_pipeline.to_nodes("node7")
+        nodes = {node.name for node in to_nodes_pipeline.nodes}
+
+        assert len(to_nodes_pipeline.nodes) == 3
+        assert nodes == {"node7", "node8", "node9"}
+
     def test_only_nodes_with_inputs(self, complex_pipeline):
         p = complex_pipeline.only_nodes_with_inputs("H@node2")
         assert _get_node_names(p) == {"node2"}


### PR DESCRIPTION
## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
`from_nodes` and `to_nodes` do not deal well with transcoded datasets. A minimal example would be a pipeline 1 -> A -> 2, where node 1 writes `A@1` and node 2 reads `A@2`. Running `from_nodes(1)` or `to_nodes(2)` should both run the entire pipeline. Instead, what happens is that `from_nodes(1)` only runs node 1, and `to_nodes(2)` only runs node 2. This PR fixes this issue.

## How has this been tested?
A new test that wouldn't previously pass was created. All other tests still run.

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](/RELEASE.md) file
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
