### PR TITLE
Change pandas.CSVDataSet type to CSVLocalDataSet in docs

### DIFF
--- a/docs/source/03_tutorial/03_set_up_data.md
+++ b/docs/source/03_tutorial/03_set_up_data.md
@@ -90,11 +90,11 @@ Let’s start this process by registering the `csv` datasets by copying the foll
 
 ```yaml
 companies:
-  type: pandas.CSVDataSet
+  type: CSVLocalDataSet
   filepath: data/01_raw/companies.csv
 
 reviews:
-  type: pandas.CSVDataSet
+  type: CSVLocalDataSet
   filepath: data/01_raw/reviews.csv
 ```
 


### PR DESCRIPTION
Replacing pandas.CSVDataSet with CSVLocalDataSet due to the tutorial throwing errors.

## Description

Using pandas.CSVDataSet throws an error while running the example

## Development notes

Changed the type to CSVLocalDataSet.

## Checklist

It's just an update to the documentation.

- [ ] Read the [contributing](/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
