### PR TITLE
[KED-996] Added Multiprocess to `run_node`

### DIFF
--- a/tests/runner/test_sequential_runner.py
+++ b/tests/runner/test_sequential_runner.py
@@ -41,7 +41,7 @@ from kedro.io import (
     MemoryDataSet,
 )
 from kedro.pipeline import Pipeline, node
-from kedro.runner import SequentialRunner
+from kedro.runner import SequentialRunner, run_node
 
 
 @pytest.fixture
@@ -224,6 +224,21 @@ class LoggingDataSet(AbstractDataSet):
 
     def _describe(self) -> Dict[str, Any]:
         return {}
+
+
+def test_run_node():
+    log = []
+    fake_catalog =  DataCatalog(
+            {
+                "in": LoggingDataSet(log, "in", "stuff"),
+                "middle": LoggingDataSet(log, "middle"),
+                "out": LoggingDataSet(log, "out"),
+            }
+        )
+    mock_node = node(lambda x: "FAKE", "in", "out")
+    run_node(mock_node, fake_catalog)
+    assert fake_catalog.datasets.out.value == "FAKE"
+    assert fake_catalog.datasets.out.log == [("load", "in")]
 
 
 class TestSequentialRunnerRelease:


### PR DESCRIPTION
Co-authored-by: Samuel Sinayoko <ss53g10@gmail.com>"

## Description
Added multiprocess to ``run_node``.
Related to  https://github.com/quantumblacklabs/kedro/issues/242

## Development notes
#242 

## Checklist

- [x] Read the [contributing](/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](/RELEASE.md) file
- [x] Added tests to cover my changes

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
