### PR TITLE
[KED-1492] [WIP] Add dry runner

### DIFF
--- a/kedro/context/context.py
+++ b/kedro/context/context.py
@@ -459,6 +459,7 @@ class KedroContext(abc.ABC):
 
         save_version = self._get_save_version()
         run_id = self.run_id or save_version
+        runner = runner or SequentialRunner()
 
         record_data = {
             "run_id": run_id,
@@ -473,6 +474,7 @@ class KedroContext(abc.ABC):
             "load_versions": load_versions,
             "pipeline_name": pipeline_name,
             "extra_params": self._extra_params,
+            "runner": type(runner).__name__,
         }
         journal = Journal(record_data)
 
@@ -481,7 +483,6 @@ class KedroContext(abc.ABC):
         )
 
         # Run the runner
-        runner = runner or SequentialRunner()
         return runner.run(filtered_pipeline, catalog)
 
     def _get_run_id(

--- a/kedro/runner/dry_runner.py
+++ b/kedro/runner/dry_runner.py
@@ -25,12 +25,43 @@
 #
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""``kedro.runner`` provides runners that are able
-to execute ``Pipeline`` instances.
+"""``DryRunner`` is an ``AbstractRunner`` implementation. It can be used to list which
+nodes would be run without actually executing anything.
 """
 
-from .dry_runner import DryRunner  # NOQA
-from .parallel_runner import ParallelRunner  # NOQA
-from .runner import AbstractRunner, run_node  # NOQA
-from .sequential_runner import SequentialRunner  # NOQA
+from kedro.io import AbstractDataSet, DataCatalog, MemoryDataSet
+from kedro.pipeline import Pipeline
+from kedro.runner.runner import AbstractRunner
+
+
+class DryRunner(AbstractRunner):
+    """``DryRunner`` is an ``AbstractRunner`` implementation. It can be used to list which
+    nodes would be run without actually executing anything.
+    """
+
+    def create_default_data_set(self, ds_name: str) -> AbstractDataSet:
+        """Factory method for creating the default data set for the runner.
+
+        Args:
+            ds_name: Name of the missing data set
+
+        Returns:
+            An instance of an implementation of AbstractDataSet to be used
+            for all unregistered data sets.
+
+        """
+        return MemoryDataSet()
+
+    def _run(self, pipeline: Pipeline, catalog: DataCatalog) -> None:
+        """The method implementing dry pipeline running.
+
+        Args:
+            pipeline: The ``Pipeline`` to run.
+            catalog: The ``DataCatalog`` from which to fetch data.
+        """
+        nodes = pipeline.nodes
+        self._logger.info(
+            "Wet run would execute %d nodes:\n%s",
+            len(nodes),
+            "\n".join(map(str, nodes)),
+        )

--- a/tests/context/test_context.py
+++ b/tests/context/test_context.py
@@ -44,7 +44,7 @@ from kedro.context import KedroContext, KedroContextError
 from kedro.extras.datasets.pandas import CSVDataSet
 from kedro.io.core import Version, generate_timestamp
 from kedro.pipeline import Pipeline, node
-from kedro.runner import ParallelRunner, SequentialRunner
+from kedro.runner import DryRunner, ParallelRunner, SequentialRunner
 
 
 def _get_local_logging_config():
@@ -414,6 +414,15 @@ class TestKedroContextRun:  # pylint: disable=too-many-public-methods
         log_msgs = [record.getMessage() for record in caplog.records]
         log_names = [record.name for record in caplog.records]
         assert "kedro.runner.parallel_runner" in log_names
+        assert "Pipeline execution completed successfully." in log_msgs
+
+    def test_dry_run_arg(self, dummy_context, dummy_dataframe, caplog):
+        dummy_context.catalog.save("cars", dummy_dataframe)
+        dummy_context.run(runner=DryRunner())
+
+        log_msgs = [record.getMessage() for record in caplog.records]
+        log_names = [record.name for record in caplog.records]
+        assert "kedro.runner.dry_runner" in log_names
         assert "Pipeline execution completed successfully." in log_msgs
 
     def test_run_with_node_names(self, dummy_context, dummy_dataframe, caplog):

--- a/tests/template/test_kedro_cli.py
+++ b/tests/template/test_kedro_cli.py
@@ -40,7 +40,7 @@ from click.testing import CliRunner
 from kedro.extras.datasets.pandas import CSVDataSet
 from kedro.io.data_catalog import DataCatalog
 from kedro.io.memory_data_set import MemoryDataSet
-from kedro.runner import ParallelRunner, SequentialRunner
+from kedro.runner import DryRunner, ParallelRunner, SequentialRunner
 
 
 @pytest.fixture(autouse=True)
@@ -213,6 +213,19 @@ class TestRunCommand:
         assert isinstance(
             fake_load_context.return_value.run.call_args_list[0][1]["runner"],
             ParallelRunner,
+        )
+
+    def test_run_successfully_dry_via_name(
+        self, fake_kedro_cli, fake_load_context
+    ):
+        result = CliRunner().invoke(
+            fake_kedro_cli.cli, ["run", "--runner=DryRunner"]
+        )
+
+        assert not result.exit_code
+        assert isinstance(
+            fake_load_context.return_value.run.call_args_list[0][1]["runner"],
+            DryRunner,
         )
 
     @pytest.mark.parametrize("config_flag", ["--config", "-c"])


### PR DESCRIPTION
## Description
There is a variety of ways in which a user can specify the set of nodes to execute (e.g. through pipeline, tags, node names, from node, to node, etc.). Executing nodes can take a long time, and so it is useful to be able to preview which nodes will be selected without actually running them. This PR creates a `DryRunner` which may be used as an alternative to the existing `SequentialRunner` and `ParallelRunner`.

## Development notes
The runner can be called through CLI by `kedro run --runner=DryRunner`. There is no `--dry` flag, since apparently `--parallel` will also be removed at some point in the relatively near future.

Example output:
```
test_sequential_runner.py F2020-03-18 14:25:30,420 - kedro.runner.dry_runner - INFO - Wet run would execute 5 nodes:
node5: random(None) -> [A]
node3: identity([A]) -> [B]
node4: identity([B]) -> [C]
node2: identity([C]) -> [D]
node1: identity([D]) -> [E]
2020-03-18 14:25:30,421 - kedro.runner.dry_runner - INFO - Pipeline execution completed successfully.
2020-03-18 14:25:30,422 - kedro.io.data_catalog - INFO - Loading data from `E` (MemoryDataSet)...
```

Testing:
- new test `test_run_successfully_dry_via_name` in `test_kedro_cli`
- new test `test_dry_run_arg` in `test_context`

Open questions/things to do/stuff I'd like help with:
- [ ] are these CLI flags/options correct?
- [ ] documentation: what should I write and where?
- [ ] manual testing: I haven't actually tried using this yet, outside the tests...
- [ ] `test_dry_run_arg` in `test_context` doesn't work and I'm not sure why...
- [ ] since `DryRunner` inherits from `AbstractRunner`, when it is used the `run` method runs two things after `self._run(pipeline, catalog)`: 1. output the message "Pipeline execution completed successfully"; 2. `return {ds_name: catalog.load(ds_name) for ds_name in free_outputs}` (hence the "Loading data" message in the above example). These don't really make sense for `DryRunner`. Should we change the implementation so these two lines of code don't run, and if so how?
- [ ] not sure what, if any, tests are needed beyond those given. I started writing some tests based on `test_sequential_runner` but decided they weren't actually testing the new functionality in any meaningful way. Something that uses `caplog` to make sure it's counted the number of nodes correctly? Seems kind of pointless...

## Checklist

- [x] Read the [contributing](../CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](../RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
