### PR TITLE
Remove newline instead of using \ for continuation

### DIFF
--- a/kedro/extras/datasets/spark/spark_hive_dataset.py
+++ b/kedro/extras/datasets/spark/spark_hive_dataset.py
@@ -126,8 +126,7 @@ class SparkHiveDataSet(AbstractDataSet):
         >>>
         >>> data = [('Alex', 31), ('Bob', 12), ('Clarke', 65), ('Dave', 29)]
         >>>
-        >>> spark_df = SparkSession.builder.getOrCreate()\
-        >>>                        .createDataFrame(data, schema)
+        >>> spark_df = SparkSession.builder.getOrCreate().createDataFrame(data, schema)
         >>>
         >>> data_set = SparkHiveDataSet(database="test_database", table="test_table",
         >>>                             write_mode="overwrite")


### PR DESCRIPTION
## Description

[Docs](https://kedro.readthedocs.io/en/stable/kedro.extras.datasets.spark.SparkHiveDataSet.html) render weird because of the backslash:

```python
...
data = [('Alex', 31), ('Bob', 12), ('Clarke', 65), ('Dave', 29)]

spark_df = SparkSession.builder.getOrCreate()                                .createDataFrame(data, schema)

data_set = SparkHiveDataSet(database="test_database", table="test_table",
...
```

Helps that I've got a general hatred for backslashes, as they're looked down upon by PEP 8.

## Checklist

- [x] Read the [contributing](../CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](../RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
