### PR TITLE
[MINOR] Fix ``_get_values_as_tuple`` return type signature

### DIFF
--- a/kedro/template/{{ cookiecutter.repo_name }}/kedro_cli.py
+++ b/kedro/template/{{ cookiecutter.repo_name }}/kedro_cli.py
@@ -190,7 +190,7 @@ def _config_file_callback(ctx, param, value):
     return value
 
 
-def _get_values_as_tuple(values: Iterable[str]) -> Tuple[str]:
+def _get_values_as_tuple(values: Iterable[str]) -> Tuple[str, ...]:
     return tuple(chain.from_iterable(value.split(",") for value in values))
 
 


### PR DESCRIPTION
## Description
As per https://docs.python.org/3/library/typing.html#typing.Tuple, "To specify a variable-length tuple of homogeneous type, use literal ellipsis, e.g. `Tuple[int, ...]`."

Before this fix, `mypy kedro_cli.py` on a Kedro project returns:

```
kedro_cli.py:193: error: Incompatible return value type (got "Tuple[str, ...]", expected "Tuple[str]")
```

## Development notes
Changed the return type signature and tested it on a `0.15.8` / `0.15.9` project.

## Checklist

- [x] Read the [contributing](../CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](../RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
