### PR TITLE
[KED-1629] Add method to enable caching of datasets in the DataCatalog

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,6 +34,7 @@
 * Added ability to read partitioned parquet file from a directory in `pandas.ParquetDataSet`.
 * Bug in `SparkDataSet` not allowing for loading data from DBFS in a Windows machine using Databricks-connect.
 * Added option to lint the project without applying the formatting changes (`kedro lint --check-only`).
+* Added method `enable_caching` to the `DataCatalog`, which wraps the catalog's datasets with a `CachedDataSet`
 
 ## Breaking changes to the API
 * Made `invalidate_cache` method on datasets private.
@@ -79,7 +80,7 @@ The list of moved files you can find in `0.15.6` release notes under `Files with
  We have upgraded `pip-tools` which is used by `kedro build-reqs` to 5.x. This `pip-tools` version requires `pip>=20.0`. To upgrade `pip`, please refer to [their documentation](https://pip.pypa.io/en/stable/installing/#upgrading-pip).
 
 ## Thanks for supporting contributions
-[@foolsgold](https://github.com/foolsgold), [Mani Sarkar](https://github.com/neomatrix369), [Priyanka Shanbhag](https://github.com/priyanka1414), [Luis Blanche](https://github.com/LuisBlanche), [Deepyaman Datta](https://github.com/deepyaman), [Antony Milne](https://github.com/AntonyMilneQB), [Panos Psimatikas](https://github.com/ppsimatikas), [Tam-Sanh Nguyen](https://github.com/tamsanh), [Tomasz Kaczmarczyk](https://github.com/TomaszKaczmarczyk)
+[@foolsgold](https://github.com/foolsgold), [Mani Sarkar](https://github.com/neomatrix369), [Priyanka Shanbhag](https://github.com/priyanka1414), [Luis Blanche](https://github.com/LuisBlanche), [Deepyaman Datta](https://github.com/deepyaman), [Antony Milne](https://github.com/AntonyMilneQB), [Panos Psimatikas](https://github.com/ppsimatikas), [Tam-Sanh Nguyen](https://github.com/tamsanh), [Tomasz Kaczmarczyk](https://github.com/TomaszKaczmarczyk), [Nikolaos Tsaousis](https://github.com/tsanikgr)
 
 # 0.15.9
 

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -661,7 +661,7 @@ class DataCatalog:
         """Wrap the selected datasets with a :class:`~kedro.io.CachedDataSet`, so that after
         the first load/save data is loaded from memory instead of the actual dataset.
 
-        If working with `kedro` pipelines`, the following code will enable caching only if
+        If working with `kedro` pipelines, the following code will enable caching only if
         a dataset is an input to 2 or more nodes, or a dataset is the output of a node and the
         input of at least one downstream node
 

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -682,9 +682,14 @@ class DataCatalog:
                     provided, it is inferred based on the data type.
         """
         counter = Counter(datasets or self._data_sets.keys())
-        for name, dataset in self._data_sets.items():
+        for name, count in counter.items():
             if (
-                not isinstance(dataset, (CachedDataSet, MemoryDataSet))
-                and counter.get(name, 0) >= count_threshold
+                name in self._data_sets
+                and not isinstance(
+                    self._data_sets[name], (CachedDataSet, MemoryDataSet)
+                )
+                and count >= count_threshold
             ):
-                self._data_sets[name] = CachedDataSet(dataset, copy_mode=copy_mode)
+                self._data_sets[name] = CachedDataSet(
+                    self._data_sets[name], copy_mode=copy_mode
+                )

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -614,3 +614,7 @@ class TestCatalogCaching:
     def test_caching_copy_mode(self, multi_catalog):
         multi_catalog.enable_caching(copy_mode="assign")
         assert multi_catalog._data_sets["abc"]._cache._copy_mode == "assign"
+
+    def test_unknown_dataset(self, multi_catalog):
+        multi_catalog.enable_caching(datasets=["abc", "bad"])
+        assert not isinstance(multi_catalog._data_sets["abc"], MemoryDataSet)


### PR DESCRIPTION
## Description
closes #345

To avoid dependency between `DataCatalog` <-> `Pipeline`, instead of passing a `Pipeline` object in the `enable_caching` method, the method expects an `Iterable[str]` of dataset names, and I have this in the docstring:

```
        If working with `kedro` pipelines`, the following code will enable caching only if
        a dataset is an input to 2 or more nodes, or a dataset is the output of a node and the
        input of at least one downstream node

        ::

            >>> pipe_datasets = chain.from_iterable(
            >>>     node.inputs + node.outputs for node in
            >>>     pipeline.nodes
            >>> )
            >>> catalog.enable_caching(pipe_datasets, count_threshold=2)
```

Let me know if you think there is a better way.

## Development notes
Unit tests

## Checklist

- [x] Read the [contributing](../CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](../RELEASE.md) file
- [x] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
