### PR TITLE
Feature/flexible api dataset

### DIFF
--- a/kedro/extras/datasets/api/api_dataset.py
+++ b/kedro/extras/datasets/api/api_dataset.py
@@ -91,10 +91,10 @@ class APIDataSet(AbstractDataSet):
                 or ``AuthBase``, ``HTTPBasicAuth`` instance for more complex cases.
             timeout: The wait time in seconds for a response, defaults to 1 minute.
                 https://requests.readthedocs.io/en/master/user/quickstart/#timeouts
-            attribute: The attribute of response to return. Normally it's either `text`, which returns
-                pure text,`json`, which returns JSON in Python Dict format, `content`, which returns
-                a raw content, or `` (empty string), which returns the reponse object itself.
-                Defaults to `text`.
+            attribute: The attribute of response to return. Normally it's either `text`, which
+                returns pure text,`json`, which returns JSON in Python Dict format, `content`,
+                which returns a raw content, or `` (empty string), which returns the reponse
+                object itself. Defaults to `text`.
 
         """
         super().__init__()
@@ -126,13 +126,14 @@ class APIDataSet(AbstractDataSet):
     def _load(self) -> Any:
         response = self._execute_request()
         if not self._attribute:
-            return response
+            output = response
         elif self._attribute == "json":
-            return response.json()
+            output = response.json()
         elif hasattr(response, self._attribute):
-            return getattr(response, self._attribute)
+            output = getattr(response, self._attribute)
         else:
             raise DataSetError("Response has no attribute: {}".format(self._attribute))
+        return output
 
     def _save(self, data: Any) -> None:
         raise DataSetError(

--- a/kedro/extras/datasets/api/api_dataset.py
+++ b/kedro/extras/datasets/api/api_dataset.py
@@ -40,8 +40,7 @@ from kedro.io.core import AbstractDataSet, DataSetError
 
 
 class APIDataSet(AbstractDataSet):
-    """``APIDataSet`` loads the data from HTTP(S) APIs
-    and returns them into either as string or json Dict.
+    """``APIDataSet`` loads the data from HTTP(S) APIs.
     It uses the python requests library: https://requests.readthedocs.io/en/master/
 
     Example:

--- a/tests/extras/datasets/api/test_api_dataset.py
+++ b/tests/extras/datasets/api/test_api_dataset.py
@@ -167,7 +167,7 @@ def test_successfully_load_with_content_response():
 
 def test_successfully_load_with_response_itself():
     api_data_set = APIDataSet(
-        url="https://raw.githubusercontent.com/quantumblacklabs/kedro/develop/img/pipeline_visualisation.png",
+        url="https://raw.githubusercontent.com/quantumblacklabs/kedro/develop/img/kedro_banner.png",
         method="GET",
         attribute="",
     )

--- a/tests/extras/datasets/api/test_api_dataset.py
+++ b/tests/extras/datasets/api/test_api_dataset.py
@@ -174,3 +174,16 @@ def test_successfully_load_with_response_itself():
     response = api_data_set.load()
     content = response.content
     assert content[1:4] == b"PNG"  # part of PNG file signature
+
+
+def test_attribute_not_found():
+    attribute = "wrong_attribute"
+    api_data_set = APIDataSet(
+        url="https://raw.githubusercontent.com/quantumblacklabs/kedro/develop/img/kedro_banner.png",
+        method="GET",
+        attribute=attribute,
+    )
+    pattern = r"Response has no attribute: {}".format(attribute)
+
+    with pytest.raises(DataSetError, match=pattern):
+        api_data_set.load()

--- a/tests/extras/datasets/api/test_api_dataset.py
+++ b/tests/extras/datasets/api/test_api_dataset.py
@@ -75,7 +75,7 @@ class TestAPIDataSet:
             method=method,
             params=TEST_PARAMS,
             headers=TEST_HEADERS,
-            json=True,
+            attribute="json",
         )
         requests_mocker.register_uri(
             method,
@@ -153,3 +153,24 @@ class TestAPIDataSet:
         )
 
         assert api_data_set.exists()
+
+
+def test_successfully_load_with_content_response():
+    api_data_set = APIDataSet(
+        url="https://raw.githubusercontent.com/quantumblacklabs/kedro/develop/img/kedro_banner.png",
+        method="GET",
+        attribute="content",
+    )
+    content = api_data_set.load()
+    assert content[1:4] == b"PNG"  # part of PNG file signature
+
+
+def test_successfully_load_with_response_itself():
+    api_data_set = APIDataSet(
+        url="https://raw.githubusercontent.com/quantumblacklabs/kedro/develop/img/pipeline_visualisation.png",
+        method="GET",
+        attribute="",
+    )
+    response = api_data_set.load()
+    content = response.content
+    assert content[1:4] == b"PNG"  # part of PNG file signature


### PR DESCRIPTION
## Description
Resolves #362
The provided `APIDataset` did not support to get contents such as image files.
Flexibility was added by this pull request.

## Development notes
Added test code.

## Checklist

- [x] Read the [contributing](../CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](../RELEASE.md) file
- [x] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
