### PR TITLE
[KED-1689] Allow JSON strings in CLI `--params` value

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
   - `kedro pipeline create` to create a modular pipeline
 * Improved the CLI speed by up to 50%.
 * Improved error handling when making a typo on the CLI. We now suggest some of the possible commands you meant to type, in `git`-style.
+* Modified the `--params` flag for `kedro run` to allow JSON input strings.
 
 ### Framework
 * All modules in `kedro.cli` and `kedro.context` have been moved into `kedro.framework.cli` and `kedro.framework.context` respectively. `kedro.cli` and `kedro.context` will be removed in future releases.
@@ -134,7 +135,7 @@ You can find the list of moved files in the [`0.15.6` release notes](https://git
  We have upgraded `pip-tools` which is used by `kedro build-reqs` to 5.x. This `pip-tools` version requires `pip>=20.0`. To upgrade `pip`, please refer to [their documentation](https://pip.pypa.io/en/stable/installing/#upgrading-pip).
 
 ## Thanks for supporting contributions
-[@foolsgold](https://github.com/foolsgold), [Mani Sarkar](https://github.com/neomatrix369), [Priyanka Shanbhag](https://github.com/priyanka1414), [Luis Blanche](https://github.com/LuisBlanche), [Deepyaman Datta](https://github.com/deepyaman), [Antony Milne](https://github.com/AntonyMilneQB), [Panos Psimatikas](https://github.com/ppsimatikas), [Tam-Sanh Nguyen](https://github.com/tamsanh), [Tomasz Kaczmarczyk](https://github.com/TomaszKaczmarczyk), [Kody Fischer](https://github.com/Klio-Foxtrot187), [Waylon Walker](https://github.com/waylonwalker)
+[@foolsgold](https://github.com/foolsgold), [Mani Sarkar](https://github.com/neomatrix369), [Priyanka Shanbhag](https://github.com/priyanka1414), [Luis Blanche](https://github.com/LuisBlanche), [Deepyaman Datta](https://github.com/deepyaman), [Antony Milne](https://github.com/AntonyMilneQB), [Panos Psimatikas](https://github.com/ppsimatikas), [Tam-Sanh Nguyen](https://github.com/tamsanh), [Tomasz Kaczmarczyk](https://github.com/TomaszKaczmarczyk), [Kody Fischer](https://github.com/Klio-Foxtrot187), [Waylon Walker](https://github.com/waylonwalker), [Nikthil Thomas Joy](https://github.com/nikhiltjoy)
 
 # 0.15.9
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -135,7 +135,7 @@ You can find the list of moved files in the [`0.15.6` release notes](https://git
  We have upgraded `pip-tools` which is used by `kedro build-reqs` to 5.x. This `pip-tools` version requires `pip>=20.0`. To upgrade `pip`, please refer to [their documentation](https://pip.pypa.io/en/stable/installing/#upgrading-pip).
 
 ## Thanks for supporting contributions
-[@foolsgold](https://github.com/foolsgold), [Mani Sarkar](https://github.com/neomatrix369), [Priyanka Shanbhag](https://github.com/priyanka1414), [Luis Blanche](https://github.com/LuisBlanche), [Deepyaman Datta](https://github.com/deepyaman), [Antony Milne](https://github.com/AntonyMilneQB), [Panos Psimatikas](https://github.com/ppsimatikas), [Tam-Sanh Nguyen](https://github.com/tamsanh), [Tomasz Kaczmarczyk](https://github.com/TomaszKaczmarczyk), [Kody Fischer](https://github.com/Klio-Foxtrot187), [Waylon Walker](https://github.com/waylonwalker), [Nikthil Thomas Joy](https://github.com/nikhiltjoy)
+[@foolsgold](https://github.com/foolsgold), [Mani Sarkar](https://github.com/neomatrix369), [Priyanka Shanbhag](https://github.com/priyanka1414), [Luis Blanche](https://github.com/LuisBlanche), [Deepyaman Datta](https://github.com/deepyaman), [Antony Milne](https://github.com/AntonyMilneQB), [Panos Psimatikas](https://github.com/ppsimatikas), [Tam-Sanh Nguyen](https://github.com/tamsanh), [Tomasz Kaczmarczyk](https://github.com/TomaszKaczmarczyk), [Kody Fischer](https://github.com/Klio-Foxtrot187), [Waylon Walker](https://github.com/waylonwalker), [Nikhil Thomas Joy](https://github.com/nikhiltjoy)
 
 # 0.15.9
 

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/kedro_cli.py
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/kedro_cli.py
@@ -28,7 +28,6 @@
 
 """Command line tools for manipulating a Kedro project.
 Intended to be invoked via `kedro`."""
-import json
 import os
 from itertools import chain
 from pathlib import Path
@@ -121,13 +120,6 @@ def _reformat_load_versions(  # pylint: disable=unused-argument
 
 
 def _split_params(ctx, param, value):
-    try:
-        value = json.loads(value)
-    except json.JSONDecodeError:
-        if value:
-            logger.info("Not a JSON entry.")
-    if isinstance(value, dict):
-        return value
     result = {}
     for item in split_string(ctx, param, value):
         item = item.split(":", 1)

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/kedro_cli.py
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/kedro_cli.py
@@ -28,6 +28,7 @@
 
 """Command line tools for manipulating a Kedro project.
 Intended to be invoked via `kedro`."""
+import json
 import os
 from itertools import chain
 from pathlib import Path
@@ -120,6 +121,11 @@ def _reformat_load_versions(  # pylint: disable=unused-argument
 
 
 def _split_params(ctx, param, value):
+    try:
+        value = json.loads(value)
+    except json.JSONDecodeError:
+        if value:
+            logger.info("Not a JSON entry.")
     if isinstance(value, dict):
         return value
     result = {}


### PR DESCRIPTION
## Description
This adds the ability to send JSON string input to the CLI.

## Development notes
I changed the cookiecutter to parse the string to JSON first, and if it doesn't succeed, it continues with the key:value logic. Tested locally with my own project

## Checklist

- [x] Read the [contributing](../CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](../RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
