### PR TITLE
Fix kedro docs html deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 install: build-docs
-	rm -rf kedro/html
-	cp -r docs/build/html kedro
+	rm -rf kedro/framework/html
+	cp -r docs/build/html kedro/framework
 	pip install .
 
 clean:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,10 +15,12 @@
 ## Bug fixes and other changes
 * Removed `/src/nodes` directory from the project template and made `kedro jupyter convert` create it on the fly if necessary.
 * Fixed a bug in `MatplotlibWriter` which prevented saving lists and dictionaries of plots locally on Windows.
+* Repair the `kedro docs` cli command
 
 ## Breaking changes to the API
 
 ## Thanks for supporting contributions
+[Tam-Sanh Nguyen](https://github.com/tamsanh)
 
 # Release 0.16.2
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,7 +15,7 @@
 ## Bug fixes and other changes
 * Removed `/src/nodes` directory from the project template and made `kedro jupyter convert` create it on the fly if necessary.
 * Fixed a bug in `MatplotlibWriter` which prevented saving lists and dictionaries of plots locally on Windows.
-* Repair the `kedro docs` cli command
+* Fixed the `kedro docs` cli command
 
 ## Breaking changes to the API
 

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
     readme = f.read()
 
 doc_html_files = [
-    name.replace("kedro/", "", 1) for name in glob("kedro/html/**/*", recursive=True)
+    name.replace("kedro/", "", 1) for name in glob("kedro/framework/html/**/*", recursive=True)
 ]
 
 template_files = []


### PR DESCRIPTION
## Description
Running `kedro docs` doesn't work in 0.16.1 due to the move to the `framework` module. When running the command, it tries to find the documents located under `framework` where they do not exist. This is because the deployment process in the `setup.py` and `Makefile` files, the `html` was not updated and so the docs were being deployed to the original `kedro/html` folder rather than the new `kedro/framework/html` folder.

## Development notes
After copying docs to the correct folder, tested with `python -m kedro docs`.
Created a virtualenv and ran `python setup.py install` and then used `kedro docs`.

## Checklist

- [X] Read the [contributing](../CONTRIBUTING.md) guidelines
- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Updated the documentation to reflect the code changes
- [X] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](../RELEASE.md) file
- [X] Added tests to cover my changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
