### PR TITLE
DOCS - Add link to github kedro-hook tag

### DIFF
--- a/docs/source/07_extend_kedro/05_plugins.md
+++ b/docs/source/07_extend_kedro/05_plugins.md
@@ -83,7 +83,7 @@ When you are ready to submit your code:
    - All `project` commands should be provided as another `click` group
    - The `click` groups are declared through the [`pkg_resources` entry_point system](https://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins)
  3. Include a `README.md` describing your `plugin`'s functionality and all dependencies that should be included
- 4. Use GitHub tagging to tag your plugin as a `kedro-plugin` so that we can find it
+ 4. Use GitHub tagging to tag your plugin as a `kedro-plugin` so that we can [find it](https://github.com/topics/kedro-hook)
 
 >*Note:* In future, we will feature a list of "Plugins by Contributors". Your plugin needs to have an [Apache 2.0 compatible license](https://www.apache.org/legal/resolved.html#category-a) to be considered for this list.
 
@@ -130,6 +130,7 @@ kedro to_json
 - [Kedro-Viz](https://github.com/quantumblacklabs/kedro-viz), a tool for visualising your Kedro pipelines
 
 ## Community-developed plugins
+_see the full list of plugins listed on the GitHub tag [kedro-hook](https://github.com/topics/kedro-hook)_
 
 - [Kedro-Pandas-Profiling](https://github.com/BrickFrog/kedro-pandas-profiling) by [Justin Malloy](https://github.com/BrickFrog), a simple plugin that uses [Pandas-Profiling](https://github.com/pandas-profiling/pandas-profiling) to profile datasets in the Kedro catalog
 - [find-kedro](https://github.com/WaylonWalker/find-kedro) by [Waylon Walker](https://github.com/WaylonWalker), automatically construct pipelines using pytest style pattern matching

--- a/docs/source/07_extend_kedro/05_plugins.md
+++ b/docs/source/07_extend_kedro/05_plugins.md
@@ -83,7 +83,7 @@ When you are ready to submit your code:
    - All `project` commands should be provided as another `click` group
    - The `click` groups are declared through the [`pkg_resources` entry_point system](https://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins)
  3. Include a `README.md` describing your `plugin`'s functionality and all dependencies that should be included
- 4. Use GitHub tagging to tag your plugin as a `kedro-plugin` so that we can [find it](https://github.com/topics/kedro-hook)
+ 4. [Use GitHub tagging to tag your plugin](https://github.com/topics/kedro-hook) as a `kedro-plugin` so that we can find it
 
 >*Note:* In future, we will feature a list of "Plugins by Contributors". Your plugin needs to have an [Apache 2.0 compatible license](https://www.apache.org/legal/resolved.html#category-a) to be considered for this list.
 


### PR DESCRIPTION
## Description
I noticed there is a recommendation to tag your hook package as a `kedro-hook` on GitHub.  This PR adds a link to the `kedro-hook` GitHub topic.  Feel free to change the wording, the main point is to add the link.

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [na] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [na] Updated the documentation to reflect the code changes
- [na] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [na] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
