### PR TITLE
Fix broken links to documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ The Kedro team pledges to foster and maintain a welcoming and friendly community
 
 We use [GitHub Issues](https://github.com/quantumblacklabs/kedro/issues) to keep track of known bugs. We keep a close eye on them and try to make it clear when we have an internal fix in progress. Before reporting a new issue, please do your best to ensure your problem hasn't already been reported. If so, it's often better to just leave a comment on an existing issue, rather than create a new one. Old issues also can often include helpful tips and solutions to common problems.
 
-If you are looking for help with your code, and the [FAQs](docs/source/06_resources/01_faq.md) in our documentation haven't helped you, please consider posting a question on [Stack Overflow](https://stackoverflow.com/questions/tagged/kedro). If you tag it `kedro` and `python`, more people will see it and may be able to help. We are unable to provide individual support via email. In the interest of community engagement we also believe that help is much more valuable if it's shared publicly, so that more people can benefit from it.
+If you are looking for help with your code, and the [FAQs](docs/source/11_faq/01_faq.md) in our documentation haven't helped you, please consider posting a question on [Stack Overflow](https://stackoverflow.com/questions/tagged/kedro). If you tag it `kedro` and `python`, more people will see it and may be able to help. We are unable to provide individual support via email. In the interest of community engagement we also believe that help is much more valuable if it's shared publicly, so that more people can benefit from it.
 
 If you're over on Stack Overflow and want to boost your points, take a look at the `kedro` tag and see if you can help others out by sharing your knowledge. It's another great way to contribute.
 
@@ -51,7 +51,7 @@ Working on your first pull request? You can learn how from these resources:
 
 Ensure you have done these:
 
-- [ ] Read through the pre-requisites in the [ReadTheDocs documentation](https://kedro.readthedocs.io/en/stable/02_getting_started/01_prerequisites.html).
+- [ ] Read through the pre-requisites in the [ReadTheDocs documentation](https://kedro.readthedocs.io/en/stable/02_get_started/01_prerequisites.html).
 - [ ] Run the below commands:
 ```
 make install-test-requirements

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can also install `kedro` using `conda`, a package and environment manager pr
 conda install -c conda-forge kedro
 ```
 
-Our [Get Started guide](https://kedro.readthedocs.io/en/stable/02_getting_started/01_prerequisites.html) contains full installation instructions, and includes how to set up Python virtual environments.
+Our [Get Started guide](https://kedro.readthedocs.io/en/stable/02_get_started/01_prerequisites.html) contains full installation instructions, and includes how to set up Python virtual environments.
 
 We also recommend the [frequently asked questions](https://kedro.readthedocs.io/en/stable/11_faq/01_faq.html) and the [API reference documentation](https://kedro.readthedocs.io/en/stable/kedro.html) for additional information.
 
@@ -125,7 +125,7 @@ Yes! Want to help build Kedro? Check out our [guide to contributing to Kedro](ht
 
 ## Where can I learn more?
 
-There is a growing community around Kedro. Have a look at the [Kedro FAQs](https://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#how-can-i-find-out-more-about-kedro) to find projects using Kedro and links to articles, podcasts and talks.
+There is a growing community around Kedro. Have a look at the [Kedro FAQs](https://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#how-can-i-find-out-more-about-kedro) to find projects using Kedro and links to articles, podcasts and talks.
 
 
 ## What licence do you use?

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To install Kedro from the Python Package Index (PyPI) simply run:
 pip install kedro
 ```
 
-You can also install `kedro` using `conda`, a package and environment manager program bundled with Anaconda. With [`conda`](https://kedro.readthedocs.io/en/stable/02_getting_started/01_prerequisites.html#working-with-virtual-environments) already installed, simply run:
+You can also install `kedro` using `conda`, a package and environment manager program bundled with Anaconda. With [`conda`](https://kedro.readthedocs.io/en/stable/02_get_started/01_prerequisites.html#virtual-environments) already installed, simply run:
 
 ```
 conda install -c conda-forge kedro
@@ -46,7 +46,7 @@ conda install -c conda-forge kedro
 
 Our [Get Started guide](https://kedro.readthedocs.io/en/stable/02_getting_started/01_prerequisites.html) contains full installation instructions, and includes how to set up Python virtual environments.
 
-We also recommend the [frequently asked questions](https://kedro.readthedocs.io/en/stable/06_resources/01_faq.html) and the [API reference documentation](https://kedro.readthedocs.io/en/stable/kedro.html) for additional information.
+We also recommend the [frequently asked questions](https://kedro.readthedocs.io/en/stable/11_faq/01_faq.html) and the [API reference documentation](https://kedro.readthedocs.io/en/stable/kedro.html) for additional information.
 
 
 ## What are the main features of Kedro?
@@ -69,13 +69,13 @@ We also recommend the [frequently asked questions](https://kedro.readthedocs.io/
 
 The [Kedro documentation](https://kedro.readthedocs.io/en/stable/) includes three examples to help get you started:
 
--   A typical "Hello World" example, for an [entry-level description of the main Kedro concepts](https://kedro.readthedocs.io/en/stable/02_getting_started/04_hello_world.html)
+-   A typical "Hello World" example, for an [entry-level description of the main Kedro concepts](https://kedro.readthedocs.io/en/stable/02_get_started/03_hello_kedro.html)
 -   The more detailed ["spaceflights" tutorial](https://kedro.readthedocs.io/en/stable/03_tutorial/02_tutorial_template.html) to give you hands-on experience as you learn about Kedro
 
 Additional documentation includes:
 
-- An overview of [Kedro architecture](https://kedro.readthedocs.io/en/stable/06_resources/02_architecture_overview.html)
-- How to [use the CLI](https://kedro.readthedocs.io/en/stable/06_resources/03_commands_reference.html) offered by `kedro_cli.py` (`kedro new`, `kedro run`, ...)
+- An overview of [Kedro architecture](https://kedro.readthedocs.io/en/stable/11_faq/02_architecture_overview.html)
+- How to [use the CLI](https://kedro.readthedocs.io/en/stable/09_development/03_commands_reference.html) offered by `kedro_cli.py` (`kedro new`, `kedro run`, ...)
 
 > *Note:* The CLI is a convenient tool for being able to run `kedro` commands but you can also invoke the Kedro CLI as a Python module with `python -m kedro`
 
@@ -106,7 +106,7 @@ Currently the core Kedro team consists of:
 * [Yetunde Dada](https://github.com/yetudada)
 * [Ivan Danov](https://github.com/idanov)
 * [Richard Westenra](https://github.com/richardwestenra)
-* [Dmitrii Deriabin](https://github.com/DmitryDeryabin)
+* [Dmitrii Deriabin](https://github.com/DmitriiDeriabinQB)
 * [Lorena Balan](https://github.com/lorenabalan)
 * [Kiyohito Kunii](https://github.com/921kiyo)
 * [Zain Patel](https://github.com/mzjp2)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -151,14 +151,14 @@ Even though this release ships a fix for project generated with `kedro==0.16.2`,
 * Removed the requirement to have all dependencies for a dataset module to use only a subset of the datasets within.
 * Added support for `pandas>=1.0`.
 * Enabled Python 3.8 compatibility. _Please note that a Spark workflow may be unreliable for this Python version as `pyspark` is not fully-compatible with 3.8 yet._
-* Renamed "features" layer to "feature" layer to be consistent with (most) other layers and the [relevant FAQ](https://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention).
+* Renamed "features" layer to "feature" layer to be consistent with (most) other layers and the [relevant FAQ](https://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention).
 
 ## Bug fixes and other changes
 * Fixed a bug where a new version created mid-run by an external system caused inconsistencies in the load versions used in the current run.
 * Documentation improvements
   * Added instruction in the documentation on how to create a custom runner).
   * Updated contribution process in `CONTRIBUTING.md` - added Developer Workflow.
-  * Documented installation of development version of Kedro in the [FAQ section](https://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#how-can-i-use-development-version-of-kedro).
+  * Documented installation of development version of Kedro in the [FAQ section](https://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#how-can-i-use-a-development-version-of-kedro).
   * Added missing `_exists` method to `MyOwnDataSet` example in 04_user_guide/08_advanced_io.
 * Fixed a bug where `PartitionedDataSet` and `IncrementalDataSet` were not working with `s3a` or `s3n` protocol.
 * Added ability to read partitioned parquet file from a directory in `pandas.ParquetDataSet`.
@@ -193,7 +193,7 @@ Even though this release ships a fix for project generated with `kedro==0.16.2`,
 
 #### General Migration
 
-**reminder** [How do I upgrade Kedro](https://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#how-do-i-upgrade-kedro) covers a few key things to remember when updating any kedro version.
+**reminder** [How do I upgrade Kedro](https://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#how-do-i-upgrade-kedro) covers a few key things to remember when updating any kedro version.
 
 #### Migration for datasets
 
@@ -314,7 +314,7 @@ You can also load data incrementally whenever it is dumped into a directory with
 
 ### New features
 
-* Added `layer` attribute for datasets in `kedro.extras.datasets` to specify the name of a layer according to [data engineering convention](https://kedro.readthedocs.io/en/latest/06_resources/01_faq.html#what-is-data-engineering-convention), this feature will be passed to [`kedro-viz`](https://github.com/quantumblacklabs/kedro-viz) in future releases.
+* Added `layer` attribute for datasets in `kedro.extras.datasets` to specify the name of a layer according to [data engineering convention](https://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention), this feature will be passed to [`kedro-viz`](https://github.com/quantumblacklabs/kedro-viz) in future releases.
 * Enabled loading a particular version of a dataset in Jupyter Notebooks and iPython, using `catalog.load("dataset_name", version="<2019-12-13T15.08.09.255Z>")`.
 * Added property `run_id` on `ProjectContext`, used for versioning using the [`Journal`](https://kedro.readthedocs.io/en/stable/04_user_guide/13_journal.html). To customise your journal `run_id` you can override the private method `_get_run_id()`.
 * Added the ability to install all optional kedro dependencies via `pip install "kedro[all]"`.

--- a/docs/source/02_get_started/05_example_project.md
+++ b/docs/source/02_get_started/05_example_project.md
@@ -48,7 +48,7 @@ Kedro also creates the following hidden files and folders:
     ├── .gitignore      # Prevent staging of unnecessary files to `git`
     ├── .ipython        # IPython startup scripts
     ├── .isort.cfg      # Configuration file for the `isort` utility when doing `kedro lint`
-    └── .kedro.yml      # Identifies the project root and [contains configuration information](https://kedro.readthedocs.io/en/latest/06_resources/02_architecture_overview.html?#kedro-yml)
+    └── .kedro.yml      # Identifies the project root and [contains configuration information](https://kedro.readthedocs.io/en/latest/11_faq/02_architecture_overview.html#kedro-yml)
 ```
 
 ### `conf/`

--- a/docs/source/03_tutorial/03_set_up_data.md
+++ b/docs/source/03_tutorial/03_set_up_data.md
@@ -2,7 +2,7 @@
 
 In this section, we discuss the data set-up phase, which is the second part of the [standard development workflow](./01_spaceflights_tutorial.md#kedro-project-development-workflow). The steps are as follows:
 
-* Add datasets to your `data/` folder, according to [data engineering convention](../10_faq/01_faq.md#what-is-data-engineering-convention)
+* Add datasets to your `data/` folder, according to [data engineering convention](../11_faq/01_faq.md#what-is-data-engineering-convention)
 * Register the datasets with the Data Catalog, which is the registry of all data sources available for use by the project `conf/base/catalog.yml`. This ensures that your code is reproducible when it references datasets in different locations and/or environments.
 
 You can find further information about [the Data Catalog](../05_data/01_data_catalog.md) in specific documentation covering advanced usage.

--- a/docs/source/06_nodes_and_pipelines/02_pipelines.md
+++ b/docs/source/06_nodes_and_pipelines/02_pipelines.md
@@ -192,7 +192,7 @@ pipeline = my_modular_pipeline_1.create_pipeline()
 Here is a list of recommendations for developing a modular pipeline:
 
 * A modular pipeline should include a `README.md`, with all the information regarding the execution of the pipeline for the end users
-* A modular pipeline _may_ have external dependencies specified in `requirements.txt`. These dependencies are _not_ currently installed by the [`kedro install`](../06_resources/03_commands_reference.md#kedro-install) command, so the users of your pipeline would have to run `pip install -r src/<python_package>/pipelines/<pipeline_name>/requirements.txt`
+* A modular pipeline _may_ have external dependencies specified in `requirements.txt`. These dependencies are _not_ currently installed by the [`kedro install`](../09_development/03_commands_reference.md#kedro-install) command, so the users of your pipeline would have to run `pip install -r src/<python_package>/pipelines/<pipeline_name>/requirements.txt`
 * To ensure portability, modular pipelines should use relative imports when accessing their own objects and absolute imports otherwise. Look at an example from `src/new_kedro_project/pipelines/modular_pipeline_1/pipeline.py` below:
 
 ```python

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -462,8 +462,8 @@ def _load_obj(class_path: str) -> Optional[object]:
             raise DataSetError(
                 f"{error} Please see the documentation on how to "
                 f"install relevant dependencies for {class_path}:\n"
-                f"https://kedro.readthedocs.io/en/stable/02_getting_started/"
-                f"02_install.html#optional-dependencies"
+                f"https://kedro.readthedocs.io/en/stable/"
+                f"04_kedro_project_setup/01_dependencies.html"
             )
         return None
 

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -169,7 +169,7 @@ class DataCatalog:
             layers: A dictionary of data set layers. It maps a layer name
                 to a set of data set names, according to the
                 data engineering convention. For more details, see
-                https://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention
+                https://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention
         Raises:
             DataSetNotFoundError: When transformers are passed for a non
                 existent data set.

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/README.md
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/README.md
@@ -15,7 +15,7 @@ Take a look at the [documentation](https://kedro.readthedocs.io) to get started.
 In order to get the best out of the template:
 
  * Please don't remove any lines from the `.gitignore` file we provide
- * Make sure your results can be reproduced by following a data engineering convention, e.g. the one we suggest [here](https://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention)
+ * Make sure your results can be reproduced by following a data engineering convention, e.g. the one we suggest [here](https://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention)
  * Don't commit any data to your repository
  * Don't commit any credentials or local configuration to your repository
  * Keep all credentials or local configuration in `conf/local/`

--- a/static/jsonschema/kedro-catalog-0.15.9.json
+++ b/static/jsonschema/kedro-catalog-0.15.9.json
@@ -79,7 +79,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -113,7 +113,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -149,7 +149,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention\n\nNote: Here you can find all supported file formats: https://biopython.org/wiki/SeqIO"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention\n\nNote: Here you can find all supported file formats: https://biopython.org/wiki/SeqIO"
               }
             }
           }
@@ -179,7 +179,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -207,7 +207,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -241,7 +241,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -273,7 +273,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -307,7 +307,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -337,7 +337,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -369,7 +369,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -415,7 +415,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -447,7 +447,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -477,7 +477,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -503,7 +503,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -537,7 +537,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -567,7 +567,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -609,7 +609,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -645,7 +645,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -677,7 +677,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -715,7 +715,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }
@@ -753,7 +753,7 @@
               },
               "layer": {
                 "type": "string",
-                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/06_resources/01_faq.html#what-is-data-engineering-convention"
+                "description": "The data layer according to the data engineering convention:\nhttps://kedro.readthedocs.io/en/stable/11_faq/01_faq.html#what-is-data-engineering-convention"
               }
             }
           }


### PR DESCRIPTION
## Description
I noticed that the link to the "Hello World" documentation was broken when I clicked it, so I checked the `README.md` for other broken links and fixed them.

## Development notes
Replaced broken links and tested manually if they work.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
