### PR TITLE
fix broken link in docs

### DIFF
--- a/docs/source/02_get_started/06_starters.md
+++ b/docs/source/02_get_started/06_starters.md
@@ -21,7 +21,7 @@ kedro new --starter=<path-to-starter>
 To create a project using the `PySpark` starter:
 
 ```bash
-kedro new --starter=https://github.com/quantumblack/kedro-starter-pyspark.git
+kedro new --starter=https://github.com/quantumblacklabs/kedro-starter-pyspark.git
 ```
 
 If no starter is provided to `kedro new`, the default Kedro template will be used, as documented in ["Creating a new project"](./04_new_project.md).


### PR DESCRIPTION
## Description

At [get-started page](https://kedro.readthedocs.io/en/stable/02_get_started/06_starters.html#how-to-use-kedro-starters), I cannot access the url `https://github.com/quantumblack/kedro-starter-pyspark.git` and I think `https://github.com/quantumblacklabs/kedro-starter-pyspark.git` is correct.

```
$ kedro new --starter=https://github.com/quantumblacklabs/kedro-starter-pyspark.git
Project Name:
=============
Please enter a human readable name for your new project.
Spaces and punctuation are allowed.
 [New Kedro Project]: 

Repository Name:
================
Please enter a directory name for your new project repository.
Alphanumeric characters, hyphens and underscores are allowed.
Lowercase is recommended.
 [new-kedro-project]: 

Python Package Name:
====================
Please enter a valid Python package name for your project package.
Alphanumeric characters and underscores are allowed.
Lowercase is recommended. Package name must start with a letter or underscore.
 [new_kedro_project]: 


Change directory to the project generated in /***/new-kedro-project

A best-practice setup includes initialising git and creating a virtual environment before running `kedro install` to install project-specific dependencies. Refer to the Kedro documentation: https://kedro.readthedocs.io/
```

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
