### PR TITLE
Delete .isort.cfg and move to setup.cfg

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,11 +17,12 @@
 * Fixed a bug for using `ParallelRunner` on Windows.
 * Modified `GBQTableDataSet` to load customized results using customized queries from Google Big Query tables.
 * Documentation improvements.
+* Absorbed `.isort.cfg` settings into `setup.cfg`
 
 ## Breaking changes to the API
 
 ## Thanks for supporting contributions
-[Ajay Bisht](https://github.com/ajb7), [Vijay Sajjanar](https://github.com/vjkr), [Deepyaman Datta](https://github.com/deepyaman), [Sebastian Bertoli](https://github.com/sebastianbertoli), [Shahil Mawjee](https://github.com/s-mawjee), [Louis Guitton](https://github.com/louisguitton), [Emanuel Ferm](https://github.com/eferm)
+[Ajay Bisht](https://github.com/ajb7), [Vijay Sajjanar](https://github.com/vjkr), [Deepyaman Datta](https://github.com/deepyaman), [Sebastian Bertoli](https://github.com/sebastianbertoli), [Shahil Mawjee](https://github.com/s-mawjee), [Louis Guitton](https://github.com/louisguitton), [Emanuel Ferm](https://github.com/eferm), [Bas Nijholt](https://github.com/basnijholt)
 
 # Release 0.16.3
 

--- a/docs/source/02_get_started/05_example_project.md
+++ b/docs/source/02_get_started/05_example_project.md
@@ -31,7 +31,7 @@ The example project directory is set out as follows:
     ├── logs            # Project output logs (not committed to version control)
     ├── notebooks       # Project related Jupyter notebooks (can be used for experimental code before moving the code to src)
     ├── README.md       # Project README
-    ├── setup.cfg       # Configuration options for `pytest` when doing `kedro test`
+    ├── setup.cfg       # Configuration options for `pytest` when doing `kedro test` and for the `isort` utility when doing `kedro lint`
     └── src             # Project source code
 ```
 
@@ -42,7 +42,6 @@ Kedro also creates the following hidden files and folders:
     ├── .coveragerc     # Configuration file for the coverage reporting when doing `kedro test`
     ├── .gitignore      # Prevent staging of unnecessary files to `git`
     ├── .ipython        # IPython startup scripts
-    ├── .isort.cfg      # Configuration file for the `isort` utility when doing `kedro lint`
     └── .kedro.yml      # Identifies the project root and [contains configuration information](https://kedro.readthedocs.io/en/latest/11_faq/02_architecture_overview.html#kedro-yml)
 ```
 

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/.isort.cfg
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/.isort.cfg
@@ -1,7 +1,0 @@
-[settings]
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88
-known_third_party=kedro

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/setup.cfg
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/setup.cfg
@@ -1,3 +1,11 @@
+[isort]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88
+known_third_party=kedro
+
 [tool:pytest]
 addopts=--cov-report term-missing
         --cov src/{{ cookiecutter.python_package }} -ra

--- a/tests/cli/test_cli_new.py
+++ b/tests/cli/test_cli_new.py
@@ -39,8 +39,8 @@ import yaml
 from kedro import __version__ as version
 from kedro.cli.cli import TEMPLATE_PATH, _fix_user_path, _get_default_config, cli
 
-FILES_IN_TEMPLATE_NO_EXAMPLE = 36
-FILES_IN_TEMPLATE_WITH_EXAMPLE = 45
+FILES_IN_TEMPLATE_NO_EXAMPLE = 35
+FILES_IN_TEMPLATE_WITH_EXAMPLE = 44
 
 
 # pylint: disable=too-many-arguments

--- a/tests/framework/cli/test_cli_new.py
+++ b/tests/framework/cli/test_cli_new.py
@@ -45,8 +45,8 @@ from kedro.framework.cli.cli import (
     cli,
 )
 
-FILES_IN_TEMPLATE_NO_EXAMPLE = 36
-FILES_IN_TEMPLATE_WITH_EXAMPLE = 45
+FILES_IN_TEMPLATE_NO_EXAMPLE = 35
+FILES_IN_TEMPLATE_WITH_EXAMPLE = 44
 
 
 # pylint: disable=too-many-arguments


### PR DESCRIPTION
## Description
Reduces the amount of bloat and retains same functionality.

In principle one could do the same for `.coveracerc`.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
