### PR TITLE
give name of function inside incorrect parameters error

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,11 +18,12 @@
 * Fixed `kedro install` for an Anaconda environment defined in `environment.yml`.
 * Fixed backwards compatibility with templates generated with older Kedro versions <0.16.5. No longer need to update `.kedro.yml` to use `kedro lint` and `kedro jupyter notebook convert`.
 * Improved documentation.
+* Improved error messages for incorrect parameters passed into a node.
 
 ## Breaking changes to the API
 
 ## Thanks for supporting contributions
-[Deepyaman Datta](https://github.com/deepyaman), [Bhavya Merchant](https://github.com/bnmerchant), [Lovkush Agarwal](https://github.com/Lovkush-A)
+[Deepyaman Datta](https://github.com/deepyaman), [Bhavya Merchant](https://github.com/bnmerchant), [Lovkush Agarwal](https://github.com/Lovkush-A), [Waylon Walker](https://github.com/waylonwalker)
 
 # Release 0.16.5
 

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -552,7 +552,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
                 ).parameters.keys()
                 raise TypeError(
                     "Inputs of function '{}' expected {}, but got {}".format(
-                        func.__code__.co_name, str(list(func_args)), str(inputs)
+                        repr(func), str(list(func_args)), str(inputs)
                     )
                 ) from exc
 

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -540,7 +540,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
                 func_name = _get_readable_func_name(func)
 
                 raise TypeError(
-                    "Inputs of '{}' expected {}, but got {}".format(
+                    "Inputs of '{}' function expected {}, but got {}".format(
                         func_name, str(list(func_args)), str(inputs)
                     )
                 ) from exc
@@ -688,7 +688,7 @@ def _to_list(element: Union[None, str, Iterable[str], Dict[str, str]]) -> List:
 
 
 def _get_readable_func_name(
-        func: Callable, outputs: Union[None, str, List[str], Dict[str, str]] = None
+    func: Callable, outputs: Union[None, str, List[str], Dict[str, str]] = None
 ) -> str:
     """Get a readable name of the function provided.
 

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -551,8 +551,8 @@ class Node:  # pylint: disable=too-many-instance-attributes
                     func, follow_wrapped=False
                 ).parameters.keys()
                 raise TypeError(
-                    "Inputs of function expected {}, but got {}".format(
-                        str(list(func_args)), str(inputs)
+                    "Inputs of function '{}' expected {}, but got {}".format(
+                        func.__code__.co_name, str(list(func_args)), str(inputs)
                     )
                 ) from exc
 

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -551,7 +551,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
                     func, follow_wrapped=False
                 ).parameters.keys()
                 raise TypeError(
-                    "Inputs of function '{}' expected {}, but got {}".format(
+                    "Inputs of '{}' expected {}, but got {}".format(
                         repr(func), str(list(func_args)), str(inputs)
                     )
                 ) from exc

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -550,9 +550,17 @@ class Node:  # pylint: disable=too-many-instance-attributes
                 func_args = inspect.signature(
                     func, follow_wrapped=False
                 ).parameters.keys()
+                try:
+                    func_name = func.__name__
+                except AttributeError:
+                    func_name = repr(func)
+
+                if "functools.partial" in func_name:
+                    func_name = "<partial>"
+
                 raise TypeError(
                     "Inputs of '{}' expected {}, but got {}".format(
-                        repr(func), str(list(func_args)), str(inputs)
+                        func_name, str(list(func_args)), str(inputs)
                     )
                 ) from exc
 

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -337,15 +337,15 @@ def inconsistent_input_kwargs():
     [
         (
             inconsistent_input_size,
-            r"Inputs of function expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
+            r"Inputs of function 'dummy_func_args' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
         ),
         (
             inconsistent_input_args,
-            r"Inputs of function expected \[\'args\'\], but got {\'a\': \'A\'}",
+            r"Inputs of function 'dummy_func_args' expected \[\'args\'\], but got {\'a\': \'A\'}",
         ),
         (
             inconsistent_input_kwargs,
-            r"Inputs of function expected \[\'kwargs\'\], but got A",
+            r"Inputs of function 'dummy_func_args' expected \[\'kwargs\'\], but got A",
         ),
     ],
 )

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -359,15 +359,17 @@ def partial_inconsistent_input_size():
         (
             inconsistent_input_args,
             (
-                r"Inputs of '<function dummy_func_args at .*>' "
-                r"expected \[\'args\'\], but got {\'a\': \'A\'}"
+                r"Inputs of '"
+                r"<function inconsistent_input_args.<locals>.dummy_func_args"
+                r" at .*>' expected \[\'kwargs\'\], but got A"
             ),
         ),
         (
             inconsistent_input_kwargs,
             (
-                r"Inputs of '<function dummy_func_args at .*>' "
-                r"expected \[\'kwargs\'\], but got A"
+                r"Inputs of '"
+                r"<function inconsistent_input_kwargs.<locals>.dummy_func_args"
+                r" at .*>' expected \[\'kwargs\'\], but got A"
             ),
         ),
         (

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -335,6 +335,7 @@ def inconsistent_input_kwargs():
 @pytest.mark.parametrize(
     "func, expected",
     [
+
         (
             inconsistent_input_size,
             r"Inputs of function 'identity' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
@@ -346,6 +347,10 @@ def inconsistent_input_kwargs():
         (
             inconsistent_input_kwargs,
             r"Inputs of function 'dummy_func_args' expected \[\'kwargs\'\], but got A",
+        ),
+        (
+            lambda : identity, ["A", "B",], ["C"],
+            r"Inputs of function '<lambda>' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
         ),
     ],
 )

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -351,23 +351,38 @@ def partial_inconsistent_input_size():
     [
         (
             inconsistent_input_size,
-            r"Inputs of '<function identity at .*>' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
+            (
+                r"Inputs of '<function identity at .*>' expected \[\'input1\'\], "
+                r"but got \[\'A\', \'B\'\]"
+            ),
         ),
         (
             inconsistent_input_args,
-            r"Inputs of '<function dummy_func_args at .*>' expected \[\'args\'\], but got {\'a\': \'A\'}",
+            (
+                r"Inputs of '<function dummy_func_args at .*>' "
+                r"expected \[\'args\'\], but got {\'a\': \'A\'}"
+            ),
         ),
         (
             inconsistent_input_kwargs,
-            r"Inputs of '<function dummy_func_args at .*>' expected \[\'kwargs\'\], but got A",
+            (
+                r"Inputs of '<function dummy_func_args at .*>' "
+                r"expected \[\'kwargs\'\], but got A"
+            ),
         ),
         (
             lambda_inconsistent_input_size,
-            r"Inputs of '<function <lambda> at .*>' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
+            (
+                r"Inputs of '<function <lambda> at .*>' "
+                r"expected \[\'input1\'\], but got \[\'A\', \'B\'\]"
+            ),
         ),
         (
             partial_inconsistent_input_size,
-            r"Inputs of 'functools.partial(<function identity at .*>)' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
+            (
+                r"Inputs of 'functools.partial(<function identity at .*>)' "
+                r"expected \[\'input1\'\], but got \[\'A\', \'B\'\]"
+            ),
         ),
     ],
 )

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -352,38 +352,33 @@ def partial_inconsistent_input_size():
         (
             inconsistent_input_size,
             (
-                r"Inputs of '<function identity at .*>' expected \[\'input1\'\], "
-                r"but got \[\'A\', \'B\'\]"
+                r"Inputs of 'identity' "
+                r"expected \[\'input1\'\], but got \[\'A\', \'B\'\]"
             ),
         ),
         (
             inconsistent_input_args,
             (
-                r"Inputs of '"
-                r"<function inconsistent_input_args.<locals>.dummy_func_args"
-                r" at .*>' expected \[\'kwargs\'\], but got A"
+                r"Inputs of 'dummy_func_args' "
+                r"expected \[\'args\'\], but got {\'a\': \'A\'}"
             ),
         ),
         (
             inconsistent_input_kwargs,
-            (
-                r"Inputs of '"
-                r"<function inconsistent_input_kwargs.<locals>.dummy_func_args"
-                r" at .*>' expected \[\'kwargs\'\], but got A"
-            ),
+            (r"Inputs of 'dummy_func_args' " r"expected \[\'kwargs\'\], but got A"),
         ),
         (
             lambda_inconsistent_input_size,
             (
-                r"Inputs of '<function <lambda> at .*>' "
+                r"Inputs of '<lambda>' "
                 r"expected \[\'input1\'\], but got \[\'A\', \'B\'\]"
             ),
         ),
         (
             partial_inconsistent_input_size,
             (
-                "Inputs of 'functools.partial(<function identity at .*>)' "
-                "expected ['input1'], but got ['A', B']"
+                r"Inputs of '<partial>' "
+                r"expected \[\'input1\'\], but got \[\'A\', \'B\'\]"
             ),
         ),
     ],

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -351,35 +351,23 @@ def partial_inconsistent_input_size():
     [
         (
             inconsistent_input_size,
-            (
-                r"Inputs of 'identity' "
-                r"expected \[\'input1\'\], but got \[\'A\', \'B\'\]"
-            ),
+            r"Inputs of 'identity' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
         ),
         (
             inconsistent_input_args,
-            (
-                r"Inputs of 'dummy_func_args' "
-                r"expected \[\'args\'\], but got {\'a\': \'A\'}"
-            ),
+            r"Inputs of 'dummy_func_args' expected \[\'args\'\], but got {\'a\': \'A\'}",
         ),
         (
             inconsistent_input_kwargs,
-            (r"Inputs of 'dummy_func_args' " r"expected \[\'kwargs\'\], but got A"),
+            r"Inputs of 'dummy_func_args' expected \[\'kwargs\'\], but got A",
         ),
         (
             lambda_inconsistent_input_size,
-            (
-                r"Inputs of '<lambda>' "
-                r"expected \[\'input1\'\], but got \[\'A\', \'B\'\]"
-            ),
+            r"Inputs of '<lambda>' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
         ),
         (
             partial_inconsistent_input_size,
-            (
-                r"Inputs of '<partial>' "
-                r"expected \[\'input1\'\], but got \[\'A\', \'B\'\]"
-            ),
+            r"Inputs of '<partial>' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
         ),
     ],
 )

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -332,7 +332,7 @@ def inconsistent_input_kwargs():
     return dummy_func_args, "A", "B"
 
 
-lambda_identity = lambda input1: input1
+lambda_identity = lambda input1: input1  # noqa: disable=E731
 
 
 def lambda_inconsistent_input_size():

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -337,7 +337,7 @@ def inconsistent_input_kwargs():
     [
         (
             inconsistent_input_size,
-            r"Inputs of function 'dummy_func_args' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
+            r"Inputs of function 'identity' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
         ),
         (
             inconsistent_input_args,

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -332,25 +332,43 @@ def inconsistent_input_kwargs():
     return dummy_func_args, "A", "B"
 
 
+lambda_identity = lambda input1: input1
+
+
+def lambda_inconsistent_input_size():
+    return lambda_identity, ["A", "B"], "C"
+
+
+partial_identity = partial(identity)
+
+
+def partial_inconsistent_input_size():
+    return partial_identity, ["A", "B"], "C"
+
+
 @pytest.mark.parametrize(
     "func, expected",
     [
 
         (
             inconsistent_input_size,
-            r"Inputs of function 'identity' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
+            r"Inputs of '<function identity at .*>' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
         ),
         (
             inconsistent_input_args,
-            r"Inputs of function 'dummy_func_args' expected \[\'args\'\], but got {\'a\': \'A\'}",
+            r"Inputs of '<function dummy_func_args at .*>' expected \[\'args\'\], but got {\'a\': \'A\'}",
         ),
         (
             inconsistent_input_kwargs,
-            r"Inputs of function 'dummy_func_args' expected \[\'kwargs\'\], but got A",
+            r"Inputs of '<function dummy_func_args at .*>' expected \[\'kwargs\'\], but got A",
         ),
         (
-            lambda : identity, ["A", "B",], ["C"],
-            r"Inputs of function '<lambda>' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
+            lambda_inconsistent_input_size,
+            r"Inputs of '<function <lambda> at .*>' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
+        ),
+        (
+            partial_inconsistent_input_size,
+            r"Inputs of 'functools.partial(<function identity at .*>)' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
         ),
     ],
 )

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -382,7 +382,7 @@ def partial_inconsistent_input_size():
         (
             partial_inconsistent_input_size,
             (
-                r"Inputs of 'functools.partial(<function identity at .*>)' "
+                r"Inputs of 'functools.partial\(\<function identity at .*\>\)' "
                 r"expected \[\'input1\'\], but got \[\'A\', \'B\'\]"
             ),
         ),

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -351,19 +351,19 @@ def partial_inconsistent_input_size():
     [
         (
             inconsistent_input_size,
-            r"Inputs of 'identity' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
+            r"Inputs of 'identity' function expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
         ),
         (
             inconsistent_input_args,
-            r"Inputs of 'dummy_func_args' expected \[\'args\'\], but got {\'a\': \'A\'}",
+            r"Inputs of 'dummy_func_args' function expected \[\'args\'\], but got {\'a\': \'A\'}",
         ),
         (
             inconsistent_input_kwargs,
-            r"Inputs of 'dummy_func_args' expected \[\'kwargs\'\], but got A",
+            r"Inputs of 'dummy_func_args' function expected \[\'kwargs\'\], but got A",
         ),
         (
             lambda_inconsistent_input_size,
-            r"Inputs of '<lambda>' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
+            r"Inputs of '<lambda>' function expected \[\'input1\'\], but got \[\'A\', \'B\'\]",
         ),
         (
             partial_inconsistent_input_size,

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -382,8 +382,8 @@ def partial_inconsistent_input_size():
         (
             partial_inconsistent_input_size,
             (
-                r"Inputs of 'functools.partial\(\<function identity at .*\>\)' "
-                r"expected \[\'input1\'\], but got \[\'A\', \'B\'\]"
+                "Inputs of 'functools.partial(<function identity at .*>)' "
+                "expected ['input1'], but got ['A', B']"
             ),
         ),
     ],

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -349,7 +349,6 @@ def partial_inconsistent_input_size():
 @pytest.mark.parametrize(
     "func, expected",
     [
-
         (
             inconsistent_input_size,
             r"Inputs of '<function identity at .*>' expected \[\'input1\'\], but got \[\'A\', \'B\'\]",


### PR DESCRIPTION
#  Description

This is a quick and simple step towards the right direction to resolve #495.

## Development notes

I ran `kedro new`, and broke one of the nodes.  There is a comparison of the current error and the updated error below.  This error is also inspected by the test framework.

### Current Error

Does not give much information to what node caused the TypeError.  While this is generally easy to figure out on small pipelines, larger pipelines can be quite intense to figure out where the error came from.  Any additional information would be greatly appreciated.

![image](https://user-images.githubusercontent.com/22648375/94995882-c8499280-0566-11eb-978a-dea841ed228a.png)


### Updated Error

The updated error will give the name of the function for full functions, but does not provide better messaging for lambdas.

![image](https://user-images.githubusercontent.com/22648375/94996913-2da08200-056d-11eb-9806-7c6ec1ed8909.png)


### Feedback

* Is the format of the message ok?
* Is there any potential that the passed in function would not have a `func.__code__.co_name` method?

## Checklist

- [X] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Updated the documentation to reflect the code changes
- [x] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [X] Added tests to cover my changes
- [X] This PR is on my personal behalf and does not represent any employer

**NOTE** No new tests were created, only modification of existing tests.

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
