### PR TITLE
Fix bad formatting for TransfomerHooks example

### DIFF
--- a/docs/source/07_extend_kedro/02_transformers.md
+++ b/docs/source/07_extend_kedro/02_transformers.md
@@ -81,6 +81,7 @@ Next, you need to update `TransformerHooks` to apply your custom transformer. Ad
 
 <details>
 <summary><b>Click to expand</b></summary>
+
 ```python
 ...
 from .memory_profile import ProfileMemoryTransformer # new import


### PR DESCRIPTION
## Description
The code example wasn't being fully rendered in a code block. Adding an extra newline between the code block and summary expander fixed this.

## Development notes
Added an extra space, and checked using github markdown preview: https://github.com/dataengineerone/kedro/blob/patch-1/docs/source/07_extend_kedro/02_transformers.md

Btw, happy to turn this into a github issue for a first timer, though it's a bit of a tiny exercise.

## Checklist

- [X] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
