### PR TITLE
added test-output.xml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ htmlcov/
 .coverage.*
 .cache
 nosetests.xml
+test-output.xml
 coverage.xml
 *.cover
 .hypothesis/


### PR DESCRIPTION
## Description

While developing #538 I followed the CONTRIBUTING.md guidelines, and setup a local development environment.  After running `pytest <path-to-module>` I ended up with a test-output.xml file that was not in the .gitignore

## Checklist

- [X] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
