### PR TITLE
Revert "Add minimal, black-compatible flake8 configuration"

### DIFF
--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -125,10 +125,12 @@ def lint(files, check_only):
             ) from exc
 
     python_call("black", ("--check",) + files if check_only else files)
-    python_call("flake8", files)
+    python_call("flake8", ("--max-line-length=88",) + files)
 
     check_flag = ("-c",) if check_only else ()
-    python_call("isort", (*check_flag, "-rc") + files)
+    python_call(
+        "isort", (*check_flag, "-rc", "-tc", "-up", "-fgw=0", "-m=3", "-w=88") + files
+    )
 
 
 @project_group.command()

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/setup.cfg
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/setup.cfg
@@ -1,7 +1,3 @@
-[flake8]
-max-line-length=88
-extend-ignore=E203
-
 [isort]
 multi_line_output=3
 include_trailing_comma=True

--- a/tests/framework/cli/test_project.py
+++ b/tests/framework/cli/test_project.py
@@ -165,8 +165,11 @@ class TestLintCommand:
         )
         expected_calls = [
             mocker.call("black", expected_files),
-            mocker.call("flake8", expected_files),
-            mocker.call("isort", ("-rc",) + expected_files),
+            mocker.call("flake8", ("--max-line-length=88",) + expected_files),
+            mocker.call(
+                "isort",
+                ("-rc", "-tc", "-up", "-fgw=0", "-m=3", "-w=88") + expected_files,
+            ),
         ]
 
         assert python_call_mock.call_args_list == expected_calls
@@ -198,8 +201,11 @@ class TestLintCommand:
         )
         expected_calls = [
             mocker.call("black", ("--check",) + expected_files),
-            mocker.call("flake8", expected_files),
-            mocker.call("isort", ("-c", "-rc") + expected_files),
+            mocker.call("flake8", ("--max-line-length=88",) + expected_files),
+            mocker.call(
+                "isort",
+                ("-c", "-rc", "-tc", "-up", "-fgw=0", "-m=3", "-w=88") + expected_files,
+            ),
         ]
 
         assert python_call_mock.call_args_list == expected_calls


### PR DESCRIPTION
Reverts quantumblacklabs/kedro#524

Unfortunately, this has to be reverted from `master` since this represents a breaking change for existing projects - if a project was generated using Kedro `0.16.*` without the change from #524 _and_ Kedro is updated to the version with that change, `kedro lint` command will break since flake8 won't be configured (setup.cfg still lacks `[flake8]` section and CLI args are already gone).

I will migrate the changes from #524 into `develop` so that they are released in Kedro `0.17.0`.