### PR TITLE
Add minimal, black-compatible flake8 configuration (Kedro 0.17.0)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,8 @@
 ## Major features and improvements
 
 ## Bug fixes and other changes
-*  Bumped maximum required `fsspec` version to 0.8.
+* Bumped maximum required `fsspec` version to 0.8.
+* Added minimal, black-compatible flake8 configuration to the project template.
 
 ## Breaking changes to the API
 * `kedro.io.DataCatalog.exists()` returns `False` when the dataset does not exist, as opposed to raising an exception.
@@ -19,6 +20,7 @@
 * `kedro new --starter` now defaults to fetching the starter template matching the installed Kedro version.
 
 ## Thanks for supporting contributions
+[Deepyaman Datta](https://github.com/deepyaman)
 
 # Upcoming 0.16.6 release
 

--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/setup.cfg
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/setup.cfg
@@ -1,3 +1,15 @@
+[flake8]
+max-line-length=88
+extend-ignore=E203
+
+[isort]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88
+known_third_party=kedro
+
 [tool:pytest]
 addopts=--cov-report term-missing
         --cov src/{{ cookiecutter.python_package }} -ra

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -126,12 +126,10 @@ def lint(files, check_only, **kwargs):  # pylint: disable=unused-argument
             ) from exc
 
     python_call("black", ("--check",) + files if check_only else files)
-    python_call("flake8", ("--max-line-length=88",) + files)
+    python_call("flake8", files)
 
     check_flag = ("-c",) if check_only else ()
-    python_call(
-        "isort", (*check_flag, "-rc", "-tc", "-up", "-fgw=0", "-m=3", "-w=88") + files
-    )
+    python_call("isort", (*check_flag, "-rc") + files)
 
 
 @project_group.command()

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/setup.cfg
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/setup.cfg
@@ -1,3 +1,7 @@
+[flake8]
+max-line-length=88
+extend-ignore=E203
+
 [isort]
 multi_line_output=3
 include_trailing_comma=True

--- a/tests/framework/cli/test_project.py
+++ b/tests/framework/cli/test_project.py
@@ -165,11 +165,8 @@ class TestLintCommand:
         )
         expected_calls = [
             mocker.call("black", expected_files),
-            mocker.call("flake8", ("--max-line-length=88",) + expected_files),
-            mocker.call(
-                "isort",
-                ("-rc", "-tc", "-up", "-fgw=0", "-m=3", "-w=88") + expected_files,
-            ),
+            mocker.call("flake8", expected_files),
+            mocker.call("isort", ("-rc",) + expected_files),
         ]
 
         assert python_call_mock.call_args_list == expected_calls
@@ -201,11 +198,8 @@ class TestLintCommand:
         )
         expected_calls = [
             mocker.call("black", ("--check",) + expected_files),
-            mocker.call("flake8", ("--max-line-length=88",) + expected_files),
-            mocker.call(
-                "isort",
-                ("-c", "-rc", "-tc", "-up", "-fgw=0", "-m=3", "-w=88") + expected_files,
-            ),
+            mocker.call("flake8", expected_files),
+            mocker.call("isort", ("-c", "-rc") + expected_files),
         ]
 
         assert python_call_mock.call_args_list == expected_calls


### PR DESCRIPTION
## Description
Applying the changes from #524 to `develop`

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
