### PR TITLE
Refine split of node names string with multiple inputs / outputs

### DIFF
--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -209,6 +209,25 @@ def split_string(ctx, param, value):  # pylint: disable=unused-argument
     return [item.strip() for item in value.split(",") if item.strip()]
 
 
+def split_node_string(ctx, param, value):  # pylint: disable=unused-argument
+    """Split string of node names separated by comma"""
+    rough_split = value.split(",")
+
+    # NB: There are still edge-cases that can break the following, but
+    # they are unlikely to happen unintentionally.
+    corrected_split = []
+    current_token_group = []
+
+    for token in rough_split:
+        current_token_group.append(token)
+
+        if token.endswith("-> None") or token.endswith("]"):
+            corrected_split.append(",".join(current_token_group))
+            current_token_group = []
+
+    return [item.strip() for item in corrected_split if item.strip()]
+
+
 def env_option(func_=None, **kwargs):
     """Add `--env` CLI option to a function."""
     default_args = dict(type=str, default=None, help=ENV_HELP)


### PR DESCRIPTION
## Description
To fix https://github.com/quantumblacklabs/kedro/issues/613

## Development notes
Rejoined tokens that are likely to belong to input/output parameters

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [x] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
