### PR TITLE
Fix deactivate command

### DIFF
--- a/docs/source/02_get_started/01_prerequisites.md
+++ b/docs/source/02_get_started/01_prerequisites.md
@@ -37,7 +37,7 @@ conda activate kedro-environment
 To exit `kedro-environment`:
 
 ```bash
-conda deactivate kedro-environment
+conda deactivate
 ```
 
 > *Note:* The `conda` virtual environment is not dependent on your current working directory and can be activated from any directory.


### PR DESCRIPTION
Remove conda environment name.
`conda deactivate` command does not accept arguments.

## Description
<!-- Why was this PR created? -->

Remove conda environment name.
`conda deactivate` command does not accept arguments.

## Development notes
<!-- What have you changed, and how has this been tested? -->

I tested on conda 4.8.3

## Checklist

- [ ] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
