### PR TITLE
Fix broken links in download commands in spaceflights tutorial

### DIFF
--- a/docs/source/03_tutorial/03_set_up_data.md
+++ b/docs/source/03_tutorial/03_set_up_data.md
@@ -27,11 +27,11 @@ Using [cURL in a Unix terminal](https://curl.haxx.se/download.html):
 
 ```bash
 # reviews
-curl -o data/01_raw/reviews.csv https://raw.githubusercontent.com/quantumblacklabs/kedro-examples/master/kedro-tutorial/data/01_raw/reviews.csv
+curl -o data/01_raw/reviews.csv https://quantumblacklabs.github.io/kedro/reviews.csv
 # companies
-curl -o data/01_raw/companies.csv https://raw.githubusercontent.com/quantumblacklabs/kedro-examples/master/kedro-tutorial/data/01_raw/companies.csv
+curl -o data/01_raw/companies.csv https://quantumblacklabs.github.io/kedro/companies.csv
 # shuttles
-curl -o data/01_raw/shuttles.xlsx https://raw.githubusercontent.com/quantumblacklabs/kedro-examples/master/kedro-tutorial/data/01_raw/shuttles.xlsx
+curl -o data/01_raw/shuttles.xlsx https://quantumblacklabs.github.io/kedro/shuttles.xlsx
 ```
 </details>
 
@@ -41,9 +41,9 @@ Using [cURL for Windows](https://curl.haxx.se/windows/):
 <summary><b>Click to expand</b></summary>
 
 ```bat
-curl -o data\01_raw\reviews.csv https://raw.githubusercontent.com/quantumblacklabs/kedro-examples/master/kedro-tutorial/data/01_raw/reviews.csv
-curl -o data\01_raw\companies.csv https://raw.githubusercontent.com/quantumblacklabs/kedro-examples/master/kedro-tutorial/data/01_raw/companies.csv
-curl -o data\01_raw\shuttles.xlsx https://raw.githubusercontent.com/quantumblacklabs/kedro-examples/master/kedro-tutorial/data/01_raw/shuttles.xlsx
+curl -o data\01_raw\reviews.csv https://quantumblacklabs.github.io/kedro/reviews.csv
+curl -o data\01_raw\companies.csv https://quantumblacklabs.github.io/kedro/companies.csv
+curl -o data\01_raw\shuttles.xlsx https://quantumblacklabs.github.io/kedro/shuttles.xlsx
 ```
 </details>
 
@@ -54,11 +54,11 @@ Using [Wget in a Unix terminal](https://www.gnu.org/software/wget/):
 
 ```bash
 # reviews
-wget -O data/01_raw/reviews.csv https://raw.githubusercontent.com/quantumblacklabs/kedro-examples/master/kedro-tutorial/data/01_raw/reviews.csv
+wget -O data/01_raw/reviews.csv https://quantumblacklabs.github.io/kedro/reviews.csv
 # companies
-wget -O data/01_raw/companies.csv https://raw.githubusercontent.com/quantumblacklabs/kedro-examples/master/kedro-tutorial/data/01_raw/companies.csv
+wget -O data/01_raw/companies.csv https://quantumblacklabs.github.io/kedro/companies.csv
 # shuttles
-wget -O data/01_raw/shuttles.xlsx https://raw.githubusercontent.com/quantumblacklabs/kedro-examples/master/kedro-tutorial/data/01_raw/shuttles.xlsx
+wget -O data/01_raw/shuttles.xlsx https://quantumblacklabs.github.io/kedro/shuttles.xlsx
 ```
 </details>
 
@@ -68,9 +68,9 @@ Using [Wget for Windows](https://eternallybored.org/misc/wget/):
 <summary><b>Click to expand</b></summary>
 
 ```bat
-wget -O data\01_raw\reviews.csv https://raw.githubusercontent.com/quantumblacklabs/kedro-examples/master/kedro-tutorial/data/01_raw/reviews.csv
-wget -O data\01_raw\companies.csv https://raw.githubusercontent.com/quantumblacklabs/kedro-examples/master/kedro-tutorial/data/01_raw/companies.csv
-wget -O data\01_raw\shuttles.xlsx https://raw.githubusercontent.com/quantumblacklabs/kedro-examples/master/kedro-tutorial/data/01_raw/shuttles.xlsx
+wget -O data\01_raw\reviews.csv https://quantumblacklabs.github.io/kedro/reviews.csv
+wget -O data\01_raw\companies.csv https://quantumblacklabs.github.io/kedro/companies.csv
+wget -O data\01_raw\shuttles.xlsx https://quantumblacklabs.github.io/kedro/shuttles.xlsx
 ```
 </details>
 


### PR DESCRIPTION
## Description
The current spaceflights tutorial has broken links in the download commands. This patch fixes that and solves #623.

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
