### PR TITLE
Allow nodes with commas in name on `kedro run`

### DIFF
--- a/docs/source/09_development/03_commands_reference.md
+++ b/docs/source/09_development/03_commands_reference.md
@@ -192,7 +192,7 @@ Kedro has options to modify pipeline runs. Here is a list of CLI arguments suppo
 +---------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------------------+
 | :code:`kedro run --to-nodes node3,node4`                                  | A list of node names which should be used as an end point                       | No                        |
 +---------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------------------+
-| :code:`kedro run --node debug_me,debug_me_too`                            | Run only nodes with specified names                                             | Yes                       |
+| :code:`kedro run --node debug_me --node debug_me_too`                     | Run only nodes with specified names                                             | Yes                       |
 +---------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------------------+
 | :code:`kedro run --runner runner_name`                                    | Run the pipeline with a specific runner. Cannot be used together with --parallel| No                        |
 +---------------------------------------------------------------------------+---------------------------------------------------------------------------------+---------------------------+

--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/cli.py
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/cli.py
@@ -223,7 +223,6 @@ def run(
     runner_class = load_obj(runner, "kedro.runner")
 
     tag = _get_values_as_tuple(tag) if tag else tag
-    node_names = _get_values_as_tuple(node_names) if node_names else node_names
 
     package_name = str(Path(__file__).resolve().parent.name)
     with KedroSession.create(package_name, env=env, extra_params=params) as session:

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/cli.py
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/cli.py
@@ -221,7 +221,6 @@ def run(
     runner_class = load_obj(runner, "kedro.runner")
 
     tag = _get_values_as_tuple(tag) if tag else tag
-    node_names = _get_values_as_tuple(node_names) if node_names else node_names
 
     package_name = str(Path(__file__).resolve().parent.name)
     with KedroSession.create(package_name, env=env, extra_params=params) as session:


### PR DESCRIPTION
## Description

Current `cli.py` in the template doesn't allow to run nodes that contain commas inside. Therefore, it's not possible to run spaceflights starter, see: https://github.com/quantumblacklabs/kedro-starter-spaceflights/pull/10

## Development notes

CLI parameter for `--node` is configured with `multiple=True`, so it already allows multiple parameters, I just drop unnecessary split by comma. Patch was tested manually on spaceflights, see: https://github.com/quantumblacklabs/kedro-starter-spaceflights/pull/10

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
