### PR TITLE
Add env and extra_params to reload_kedro() line magic

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 # Upcoming Release 0.17.1
 
 ## Major features and improvements
-* Add `env` and `extra_params` to `reload_kedro()` line magic.
+* Added `env` and `extra_params` to `reload_kedro()` line magic.
 
 ## Bug fixes and other changes
 * The version of a packaged modular pipeline now defaults to the version of the project package.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,12 +1,14 @@
 # Upcoming Release 0.17.1
 
 ## Major features and improvements
+* Add `env` and `extra_params` to `reload_kedro()` line magic.
 
 ## Bug fixes and other changes
 * The version of a packaged modular pipeline now defaults to the version of the project package.
 
 ## Thanks for supporting contributions
-
+[Mariana Silva](https://github.com/marianansilva),
+[Kiyohito Kunii](https://github.com/921kiyo)
 
 # Release 0.17.0
 

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/.ipython/profile_default/startup/00-kedro-init.py
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/.ipython/profile_default/startup/00-kedro-init.py
@@ -1,8 +1,9 @@
 import logging.config
 import sys
 from pathlib import Path
+from typing import Any, Dict
 
-from IPython.core.magic import register_line_magic, needs_local_scope
+from IPython.core.magic import needs_local_scope, register_line_magic
 
 # Find the project root (./../../../)
 from kedro.framework.startup import _get_project_metadata
@@ -12,7 +13,7 @@ project_path = Path(__file__).parents[3].resolve()
 
 
 @register_line_magic
-def reload_kedro(path, line=None):
+def reload_kedro(path, line=None, env: str = None, extra_params: Dict[str, Any] = None):
     """Line magic which reloads all Kedro default variables."""
     global startup_error
     global context
@@ -51,7 +52,9 @@ def reload_kedro(path, line=None):
         for module in to_remove:
             del sys.modules[module]
 
-        session = KedroSession.create(metadata.package_name, path)
+        session = KedroSession.create(
+            metadata.package_name, path, env=env, extra_params=extra_params
+        )
         _activate_session(session, force=True)
         logging.debug("Loading the context from %s", str(path))
         context = session.load_context()


### PR DESCRIPTION
## Description
Often when using kedro users will leverage the `env` and `extra_params` (this usually defined in `globals.yaml`) to parameterise where data is physically persisted. 
We understand that currently the way around would be to execute the code bellow when inside the ipython session. We purpose to change the ipython startup file so make the process more intuitive to the users.
Before:
```
from kedro.framework.session import KedroSession

session = KedroSession.create("<your-kedro-project-package-name>", env="<your-env>", extra_params="<your-extra-params>")
context = session.load_context()
```
After:
```
%reload_kedro("<your-kedro-project-package-name>", env="<your-env>", extra_params="<your-extra-params>")
```

## Development notes


## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
