### PR TITLE
Make DataCatalog::shallow_copy support layers

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@
 * Added fix to prevent new lines being added to pandas CSV datasets.
 * Fixed issue with loading a versioned `SparkDataSet` in the interactive workflow.
 * Kedro CLI now checks `pyproject.toml` for a `tool.kedro` section before treating the project as a Kedro project
+* Added fix to `DataCatalog::shallow_copy` now it should copy layers
 
 ## Breaking changes to the API
 

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -694,6 +694,7 @@ class DataCatalog:
             transformers=self._transformers,
             default_transformers=self._default_transformers,
             journal=self._journal,
+            layers=self.layers,
         )
 
     def __eq__(self, other):
@@ -702,11 +703,13 @@ class DataCatalog:
             self._transformers,
             self._default_transformers,
             self._journal,
+            self.layers,
         ) == (
             other._data_sets,
             other._transformers,
             other._default_transformers,
             other._journal,
+            other.layers,
         )
 
     def confirm(self, name: str) -> None:

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -103,7 +103,8 @@ def multi_catalog(mocker):
     csv = CSVDataSet(filepath="abc.csv")
     parq = ParquetDataSet(filepath="xyz.parq")
     journal = mocker.Mock()
-    return DataCatalog({"abc": csv, "xyz": parq}, journal=journal)
+    layers={"raw": ["csv"], "model": ["xyz.parq"]}
+    return DataCatalog({"abc": csv, "xyz": parq}, journal=journal, layers=layers)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

It appears that `DataCatalog::shallow_copy` does not copying data layers therefore there is no way to access data layers from hooks which limits the possibilities for plugins developers.


## Development notes

I did very small changes to DataCatalog class and updated tests to validate them. 

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [x] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
