### PR TITLE
Improve VSCode debugging documentation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,8 @@
 * Exposed `--to-outputs` option in the CLI, throughout the codebase, and as part of hooks specifications.
 * Fixed a bug where `ParquetDataSet` wasn't creating parent directories on the fly.
 * Added `blacken-docs` pre-commit linter to ensure all snippets in the documentation are `black`ed.
-* Updated the pyspark `CustomContext` example to reflect revised `KedroContext` initialisation args
+* Updated the pyspark `CustomContext` example to reflect revised `KedroContext` initialisation args.
+* Improved and fixed the VSCode debugging documentation.
 
 ## Breaking changes to the API
 

--- a/docs/source/09_development/01_set_up_vscode.md
+++ b/docs/source/09_development/01_set_up_vscode.md
@@ -40,7 +40,7 @@ python -c 'import sys, os.path; print(os.path.join(os.path.dirname(sys.executabl
 
 We're going to need you to modify your `tasks.json`. To do this, go to **Terminal > Configure Tasks...** on your menu and open up `tasks.json` in the editor. Modify it with the following:
 
-```json
+```
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // Kedro tasks
@@ -118,7 +118,7 @@ Go to **Debug > Add Configurations**.
 
 Edit the `launch.json` that opens in the editor with:
 
-```json
+```
 {
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.

--- a/docs/source/09_development/01_set_up_vscode.md
+++ b/docs/source/09_development/01_set_up_vscode.md
@@ -40,7 +40,7 @@ python -c 'import sys, os.path; print(os.path.join(os.path.dirname(sys.executabl
 
 We're going to need you to modify your `tasks.json`. To do this, go to **Terminal > Configure Tasks...** on your menu and open up `tasks.json` in the editor. Modify it with the following:
 
-```
+```json
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // Kedro tasks
@@ -100,14 +100,14 @@ To start a build, go to **Terminal > Run Build Task...** or press `Cmd + Shift +
 
 ## Debugging
 
-To debug, you will first need to create an `.env` file in your project root. Add the full path to the `./src/` folder to the *PYTHONPATH* environment variable in the `.env` file:
+To debug, you _may_ need to create an `.env` file in your project root. Add the full path to the `./src/` folder to the *PYTHONPATH* environment variable in the `.env` file:
 
 ```console
 # In macOS / Linux:
 PYTHONPATH=/path/to/project/src:$PYTHONPATH
 
 # In Windows
-set PYTHONPATH=C:/path/to/project/src;%PYTHONPATH%
+PYTHONPATH=C:/path/to/project/src;%PYTHONPATH%
 ```
 
 You can find more information about setting up environmental variables [here](https://code.visualstudio.com/docs/python/environments#_environment-variable-definitions-file).
@@ -118,7 +118,7 @@ Go to **Debug > Add Configurations**.
 
 Edit the `launch.json` that opens in the editor with:
 
-```
+```json
 {
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.
@@ -129,8 +129,11 @@ Edit the `launch.json` that opens in the editor with:
             "name": "Python: Kedro Run",
             "type": "python",
             "request": "launch",
-            "program": "${workspaceFolder}/src/<your_project_package>/run.py",
             "console": "integratedTerminal",
+            "module": "kedro",
+            "args": ["run"]
+            // Any other arguments should be passed as a comma-seperated-list
+            // e.g "args": ["run", "--pipeline", "pipeline_name"]
         }
     ]
 }

--- a/kedro/extras/datasets/geopandas/geojson_dataset.py
+++ b/kedro/extras/datasets/geopandas/geojson_dataset.py
@@ -96,10 +96,10 @@ class GeoJSONDataSet(AbstractVersionedDataSet):
                 Note: `http(s)` doesn't support versioning.
             load_args: GeoPandas options for loading GeoJSON files.
                 Here you can find all available arguments:
-                https://geopandas.org/reference/geopandas.read_file.html
+                https://geopandas.org/docs/reference/api/geopandas.read_file.html#geopandas.read_file
             save_args: GeoPandas options for saving geojson files.
                 Here you can find all available arguments:
-                https://geopandas.org/reference.html#geopandas.GeoDataFrame.to_file
+                https://geopandas.org/docs/reference/api/geopandas.GeoDataFrame.to_file.html#geopandas.GeoDataFrame.to_file
                 The default_save_arg driver is 'GeoJSON', all others preserved.
             version: If specified, should be an instance of
                 ``kedro.io.core.Version``. If its ``load`` attribute is


### PR DESCRIPTION
## Description

The current recommended configuration is inflexible and doesn't allow for specifying CLI arguments. It also requires an `.env` file to be set-up.

I've replaced this with a different approach that is more flexible and intuitive, and doesn't require an `.env` file that fiddles around with the `PYTHONPATH` (though I've left the `.env` file instructions in for safety, but qualified it with "may need to be used").

I've also fixed the Windows settings for the `.env` file - for the same reason that on Unix, you don't need `export A=B` in the `.env` file (you instead need just `A=B`) you don't need `set A=B` on Windows.

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [x] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
