### PR TITLE
Fix conflict on release notes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,11 +2,21 @@
 
 ## Major features and improvements
 * Added support for `compress_pickle` backend to `PickleDataSet`.
+* Refactored the way pipelines are loaded so you don't need a `KedroContext` instance. You will now be able to run:
+
+```python
+from kedro.framework.project import pipelines
+
+print(pipelines)
+```
+
+* Projects generated with kedro>=0.17.2 can specify the project's pipelines in `pipeline_registry.py` rather than `hooks.py`.
 
 ## Bug fixes and other changes
 * If `settings.py` is not importable, the errors will be surfaced earlier in the process, rather than at runtime.
 
 ## Breaking changes to the API
+* `kedro pipeline list` and `kedro pipeline describe` no longer accept redundant `--env` parameter.
 
 ## Thanks for supporting contributions
 [Sasaki Takeru](https://github.com/takeru/)


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Follow up of https://github.com/quantumblacklabs/private-kedro/pull/1017, for some reason the sync is still detecting conflicts. This just copy-pastes the contents of `RELEASE.md` from `master` branch of private repo.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
