### PR TITLE
Feature/build-reqs options can be passed from the install cli command

### DIFF
--- a/docs/source/04_kedro_project_setup/01_dependencies.md
+++ b/docs/source/04_kedro_project_setup/01_dependencies.md
@@ -19,6 +19,8 @@ The `build-reqs` command will:
 
 To further update the project requirements, you should modify `src/requirements.in` (not `src/requirements.txt`) and re-run `kedro build-reqs`.
 
+> Any extra arguments for the `pip-compile` command can be directly passed as extra flags to `kedro build-reqs`. For example, if you need to install private python packages, you can add your private pypi repository to the repositories `pip-compile` will search in using `kedro build-reqs --extra-index-url="https://private.pypi.repository/simple/"` (see `pip-compile -h` for all the available extra arguments).
+
 
 ## `kedro install`
 
@@ -45,6 +47,9 @@ kedro install --build-reqs
 ```
 
 In some cases, such as a production setting, this is useful to eliminate ambiguity and specify exactly the version of each dependency that is installed.
+
+> Note that you can pass extra arguments to the `kedro build-reqs` triggered by the `kedro install` command using the `--build-reqs-args` flag (e.g.: `kedro install --build-reqs-args="--annotate"`).
+
 
 ## Workflow dependencies
 

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -138,7 +138,7 @@ def lint(
 )
 @click.option(
     "--build-reqs-args",
-    "compile_arguments",
+    "compile_args",
     multiple=True,
     default=[],
     help="Extra arguments to be passed to the `pip-compile` command.",

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -136,8 +136,15 @@ def lint(
     help="Run `pip-compile` on project requirements before install. "
     "By default runs only if `src/requirements.in` file doesn't exist.",
 )
+@click.option(
+    "--build-reqs-args",
+    "compile_arguments",
+    multiple=True,
+    default=[],
+    help="Extra arguments to be passed to the `pip-compile` command.",
+)
 @click.pass_obj  # this will pass the metadata as first argument
-def install(metadata: ProjectMetadata, compile_flag):
+def install(metadata: ProjectMetadata, compile_flag, compile_args):
     """Install project dependencies from both requirements.txt
     and environment.yml (optional)."""
     # we cannot use `context.project_path` as in other commands since
@@ -154,7 +161,7 @@ def install(metadata: ProjectMetadata, compile_flag):
     default_compile = bool(compile_flag is None and not requirements_in.is_file())
     do_compile = compile_flag or default_compile
     if do_compile:
-        _build_reqs(source_path)
+        _build_reqs(source_path, compile_args)
 
     pip_command = ["install", "-U", "-r", str(requirements_txt)]
 


### PR DESCRIPTION
## Description

Kedro uses `pip-compile` to keep the `requirements.txt` file up to date.
Any arguments/options to be passed to `pip-compile` can currently be directly added to the `kedro build-reqs` command.

However, when running the initial `kedro install` command (which then conditionally triggers `kedro build-reqs`), the `pip-compile` options cannot be passed.

We found it problematic as `pip-compile` by default adds any extra configuration found in the local `~/.pip/pip.conf` file to the generated `requirements.txt`, including for example any credentials to private pypi repositories present in that file (see https://github.com/jazzband/pip-tools/issues/1099).
 
The workaround for now is to first run `kedro install` and then immediately run `kedro build-reqs --no-emit-index-url` to prevent those credentials to be leaked into the generated `requirements.txt`, as `kedro build-reqs` already accepts extra arguments to be passed to `pip-compile`.

This PR adds a new `--build-reqs-args` optional flag to the `kedro install` cli command to allow directly passing any extra argument at the initial install phase.  

## Development notes

A new `--build-reqs-args` has been added as option to the `install` cli command, and those options are directly passed to the [_build_reqs](https://github.com/quantumblacklabs/kedro/blob/master/kedro/framework/cli/project.py#L61) function.

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
