### PR TITLE
Let PartitionedDataSet lazily materialize data to save

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,12 +13,14 @@
 * Fixed a bug where `kedro ipython` and `kedro jupyter notebook` didn't work if the `PYTHONPATH` was already set.
 * Update the IPython extension to allow passing `env` and `extra_params` to `reload_kedro`  similar to how the IPython script works.
 * `kedro info` now outputs if a plugin has any `hooks` or `cli_hooks` implemented.
+* `PartitionedDataSet` now supports lazily materializing data on save.
 
 ## Minor breaking changes to the API
 
 ## Upcoming deprecations for Kedro 0.18.0
 
 ## Thanks for supporting contributions
+[Lou Kratz](https://github.com/lou-k)
 
 # Release 0.17.3
 

--- a/kedro/io/partitioned_data_set.py
+++ b/kedro/io/partitioned_data_set.py
@@ -264,6 +264,8 @@ class PartitionedDataSet(AbstractDataSet):
             # join the protocol back since tools like PySpark may rely on it
             kwargs[self._filepath_arg] = self._join_protocol(partition)
             dataset = self._dataset_type(**kwargs)  # type: ignore
+            if callable(partition_data):
+                partition_data = partition_data()
             dataset.save(partition_data)
         self._invalidate_caches()
 

--- a/tests/io/test_partitioned_dataset.py
+++ b/tests/io/test_partitioned_dataset.py
@@ -108,6 +108,23 @@ class TestPartitionedDataSetLocal:
         reloaded_data = loaded_partitions[part_id]()
         assert_frame_equal(reloaded_data, original_data)
 
+    @pytest.mark.parametrize("dataset", LOCAL_DATASET_DEFINITION)
+    @pytest.mark.parametrize("suffix", ["", ".csv"])
+    def test_lazy_save(self, dataset, local_csvs, suffix):
+        pds = PartitionedDataSet(str(local_csvs), dataset, filename_suffix=suffix)
+
+        def original_data():
+            return pd.DataFrame({"foo": 42, "bar": ["a", "b", None]})
+
+        part_id = "new/data"
+        pds.save({part_id: original_data})
+
+        assert (local_csvs / "new" / ("data" + suffix)).is_file()
+        loaded_partitions = pds.load()
+        assert part_id in loaded_partitions
+        reloaded_data = loaded_partitions[part_id]()
+        assert_frame_equal(reloaded_data, original_data())
+
     def test_save_invalidates_cache(self, local_csvs, mocker):
         """Test that save calls invalidate partition cache"""
         pds = PartitionedDataSet(str(local_csvs), "pandas.CSVDataSet")


### PR DESCRIPTION
## Description
The `PartititionedDataSet` is great for very large data sets (i.e., ones that won't fit in RAM), but it's `save` function requires all data frames to be in memory. As discussed in https://github.com/quantumblacklabs/kedro/issues/499, it would be advantageous for the `save` function to support a dictionary of callables, much like the `load` function returns. This would enable an entire large dataset to be processed and moved down a pipeline without storing the whole thing in RAM.

## Development notes
* Added a check in `PartititionedDataSet.save` to see if the value of the dictionary is a callable. If it is, it calls it.
* Add a unit test for `PartititionedDataSet.save` for this case
* Updated the documentation page for this case.
* As noted in the [issue](https://github.com/quantumblacklabs/kedro/issues/499), this causes saves to occur after the node_run hook, which may cause unexpected behavior. I've noted this in the updated documentation.

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [x] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
