### PR TITLE
Fix: Add EmailMessageDataSet to doctree

### DIFF
--- a/docs/source/14_api_docs/kedro.extras.datasets.rst
+++ b/docs/source/14_api_docs/kedro.extras.datasets.rst
@@ -14,10 +14,11 @@ kedro.extras.datasets
    kedro.extras.datasets.api.APIDataSet
    kedro.extras.datasets.biosequence.BioSequenceDataSet
    kedro.extras.datasets.dask.ParquetDataSet
+   kedro.extras.datasets.email.EmailMessageDataSet
    kedro.extras.datasets.geopandas.GeoJSONDataSet
-   kedro.extras.datasets.matplotlib.MatplotlibWriter
    kedro.extras.datasets.holoviews.HoloviewsWriter
    kedro.extras.datasets.json.JSONDataSet
+   kedro.extras.datasets.matplotlib.MatplotlibWriter
    kedro.extras.datasets.networkx.NetworkXDataSet
    kedro.extras.datasets.pandas.CSVDataSet
    kedro.extras.datasets.pandas.ExcelDataSet


### PR DESCRIPTION
Added EmailMessageDataSet to docs

## Description
Simply added emailmessagedataset to doctree as I saw it was missing. I also reordered the datasets alphabetically (matplotlib was out of order). 