### PR TITLE
Fix: Add EmailMessageDataSet to doctree

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,7 @@
 * `kedro info` now outputs if a plugin has any `hooks` or `cli_hooks` implemented.
 * `PartitionedDataSet` now supports lazily materializing data on save.
 * `kedro pipeline describe` now defaults to the `__default__` pipeline when no pipeline name is provided and also shows the namespace the nodes belong to.
+* `EmailMessageDataSet` added to doctree.
 
 ## Minor breaking changes to the API
 
@@ -22,6 +23,7 @@
 
 ## Thanks for supporting contributions
 [Lou Kratz](https://github.com/lou-k)
+[Lucas Jamar](https://github.com/lucasjamar/)
 
 # Release 0.17.3
 

--- a/docs/source/14_api_docs/kedro.extras.datasets.rst
+++ b/docs/source/14_api_docs/kedro.extras.datasets.rst
@@ -14,10 +14,11 @@ kedro.extras.datasets
    kedro.extras.datasets.api.APIDataSet
    kedro.extras.datasets.biosequence.BioSequenceDataSet
    kedro.extras.datasets.dask.ParquetDataSet
+   kedro.extras.datasets.email.EmailMessageDataSet
    kedro.extras.datasets.geopandas.GeoJSONDataSet
-   kedro.extras.datasets.matplotlib.MatplotlibWriter
    kedro.extras.datasets.holoviews.HoloviewsWriter
    kedro.extras.datasets.json.JSONDataSet
+   kedro.extras.datasets.matplotlib.MatplotlibWriter
    kedro.extras.datasets.networkx.NetworkXDataSet
    kedro.extras.datasets.pandas.CSVDataSet
    kedro.extras.datasets.pandas.ExcelDataSet


### PR DESCRIPTION
Added EmailMessageDataSet to docs

## Description
Added EmailMessageDataSet to docs and reoredered Matplotlib to correct alphabetical order

## Development notes
Added EmailMessageDataSet to docs and reordered Matplotlib to correct alphabetical order

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
