### PR TITLE
Added smb protocol with test

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,6 +19,7 @@
 * `EmailMessageDataSet` added to doctree.
 * When node inputs do not pass validation, the error message is now shown as the most recent exception in the traceback ([Issue #761](https://github.com/quantumblacklabs/kedro/issues/761)).
 * `kedro pipeline package` now only packages the parameter file that exactly matches the pipeline name specified and the parameter files in a directory with the pipeline name.
+* Added [smb](https://filesystem-spec.readthedocs.io/en/latest/_modules/fsspec/implementations/smb.html) to supported filesystem protocols.
 
 ## Minor breaking changes to the API
 

--- a/docs/source/05_data/01_data_catalog.md
+++ b/docs/source/05_data/01_data_catalog.md
@@ -45,7 +45,6 @@ The following prepends are available:
 - **HTTP(s)**: ``http://`` or ``https://`` for reading data directly from HTTP web servers.
 - **SMB**: ``smb://`` for reading and writing data to a shared network drive.
 
-
 `fsspec` also provides other file systems, such as SSH, FTP and WebHDFS. See the [documentation](https://filesystem-spec.readthedocs.io/en/latest/api.html#implementations) for more information.
 
 ## Data Catalog `*_args` parameters

--- a/docs/source/05_data/01_data_catalog.md
+++ b/docs/source/05_data/01_data_catalog.md
@@ -43,6 +43,8 @@ The following prepends are available:
   resource using gcsfs (in development).
 - **Azure Blob Storage / Azure Data Lake Storage Gen2**: `abfs://` - Azure Blob Storage, typically used when working on an Azure environment.
 - **HTTP(s)**: ``http://`` or ``https://`` for reading data directly from HTTP web servers.
+- **SMB**: ``smb://`` for reading and writing data to a shared network drive.
+
 
 `fsspec` also provides other file systems, such as SSH, FTP and WebHDFS. See the [documentation](https://filesystem-spec.readthedocs.io/en/latest/api.html#implementations) for more information.
 

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -57,7 +57,7 @@ VERSION_KEY = "version"
 HTTP_PROTOCOLS = ("http", "https")
 PROTOCOL_DELIMITER = "://"
 CLOUD_PROTOCOLS = ("s3", "gcs", "gs", "adl", "abfs")
-SMB_PROTOCOLS = ("smb")
+SMB_PROTOCOLS = "smb"
 
 
 class DataSetError(Exception):

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -57,7 +57,7 @@ VERSION_KEY = "version"
 HTTP_PROTOCOLS = ("http", "https")
 PROTOCOL_DELIMITER = "://"
 CLOUD_PROTOCOLS = ("s3", "gcs", "gs", "adl", "abfs")
-SMB_PROTOCOLS = "smb"
+SMB_PROTOCOLS = ("smb")
 
 
 class DataSetError(Exception):

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -57,6 +57,7 @@ VERSION_KEY = "version"
 HTTP_PROTOCOLS = ("http", "https")
 PROTOCOL_DELIMITER = "://"
 CLOUD_PROTOCOLS = ("s3", "gcs", "gs", "adl", "abfs")
+SMB_PROTOCOLS = ("smb")
 
 
 class DataSetError(Exception):
@@ -682,7 +683,7 @@ def _parse_filepath(filepath: str) -> Dict[str, str]:
             host_with_port = parsed_path.netloc.rsplit("@", 1)[-1]
             host = host_with_port.rsplit(":", 1)[0]
             options["path"] = host + options["path"]
-        else:
+        elif protocol in SMB_PROTOCOLS:
             options["path"] = parsed_path.netloc + options["path"]
 
     return options

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -57,7 +57,7 @@ VERSION_KEY = "version"
 HTTP_PROTOCOLS = ("http", "https")
 PROTOCOL_DELIMITER = "://"
 CLOUD_PROTOCOLS = ("s3", "gcs", "gs", "adl", "abfs")
-SMB_PROTOCOLS = ("smb")
+SMB_PROTOCOLS = ("smb", )
 
 
 class DataSetError(Exception):

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -57,7 +57,7 @@ VERSION_KEY = "version"
 HTTP_PROTOCOLS = ("http", "https")
 PROTOCOL_DELIMITER = "://"
 CLOUD_PROTOCOLS = ("s3", "gcs", "gs", "adl", "abfs")
-SMB_PROTOCOLS = "smb"
+SMB_PROTOCOLS = ("smb", )
 
 
 class DataSetError(Exception):

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -682,6 +682,8 @@ def _parse_filepath(filepath: str) -> Dict[str, str]:
             host_with_port = parsed_path.netloc.rsplit("@", 1)[-1]
             host = host_with_port.rsplit(":", 1)[0]
             options["path"] = host + options["path"]
+        else:
+            options["path"] = parsed_path.netloc + options["path"]
 
     return options
 

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -57,7 +57,7 @@ VERSION_KEY = "version"
 HTTP_PROTOCOLS = ("http", "https")
 PROTOCOL_DELIMITER = "://"
 CLOUD_PROTOCOLS = ("s3", "gcs", "gs", "adl", "abfs")
-SMB_PROTOCOLS = ("smb", )
+SMB_PROTOCOLS = "smb"
 
 
 class DataSetError(Exception):

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -93,6 +93,10 @@ class TestCoreFunctions:
             ("adl://bucket/file.txt", {"protocol": "adl", "path": "bucket/file.txt"}),
             ("abfs://bucket/file.txt", {"protocol": "abfs", "path": "bucket/file.txt"}),
             (
+                    "smb://username:password@myhost:8080/folder/file.txt",
+                    {"protocol": "smb", "path": "username:password@myhost:8080/folder/file.txt"}
+            ),
+            (
                 "hdfs://namenode:8020/file.txt",
                 {"protocol": "hdfs", "path": "/file.txt"},
             ),

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -96,8 +96,8 @@ class TestCoreFunctions:
                 "smb://username:password@myhost:8080/folder/file.txt",
                 {
                     "protocol": "smb",
-                    "path": "username:password@myhost:8080/folder/file.txt"
-                }
+                    "path": "username:password@myhost:8080/folder/file.txt",
+                },
             ),
             (
                 "hdfs://namenode:8020/file.txt",

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -94,7 +94,10 @@ class TestCoreFunctions:
             ("abfs://bucket/file.txt", {"protocol": "abfs", "path": "bucket/file.txt"}),
             (
                 "smb://username:password@myhost:8080/folder/file.txt",
-                {"protocol": "smb", "path": "username:password@myhost:8080/folder/file.txt"}
+                {
+                    "protocol": "smb",
+                    "path": "username:password@myhost:8080/folder/file.txt"
+                }
             ),
             (
                 "hdfs://namenode:8020/file.txt",

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -93,8 +93,8 @@ class TestCoreFunctions:
             ("adl://bucket/file.txt", {"protocol": "adl", "path": "bucket/file.txt"}),
             ("abfs://bucket/file.txt", {"protocol": "abfs", "path": "bucket/file.txt"}),
             (
-                    "smb://username:password@myhost:8080/folder/file.txt",
-                    {"protocol": "smb", "path": "username:password@myhost:8080/folder/file.txt"}
+                "smb://username:password@myhost:8080/folder/file.txt",
+                {"protocol": "smb", "path": "username:password@myhost:8080/folder/file.txt"}
             ),
             (
                 "hdfs://namenode:8020/file.txt",


### PR DESCRIPTION
This solves https://github.com/quantumblacklabs/kedro/issues/765

## Description
Added else for filesystems that contain "netloc" but are not cloud protocols.

## Development notes
Added a simple test to ensure the username, password, host and port are returned in the path of smb files

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [x] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
