### PR TITLE
docs: include instructions for pdf

### DIFF
--- a/kedro/extras/datasets/matplotlib/matplotlib_writer.py
+++ b/kedro/extras/datasets/matplotlib/matplotlib_writer.py
@@ -65,7 +65,7 @@ class MatplotlibWriter(AbstractVersionedDataSet):
         >>> plt.close()
         >>> single_plot_writer.save(plt)
         >>>
-        >>> # MatplotlibWriter can output other formats as well, such as PDF files. 
+        >>> # MatplotlibWriter can output other formats as well, such as PDF files.
         >>> # For this, we need to specify the format:
         >>> plt.plot([1, 2, 3], [4, 5, 6])
         >>> single_plot_writer = MatplotlibWriter(

--- a/kedro/extras/datasets/matplotlib/matplotlib_writer.py
+++ b/kedro/extras/datasets/matplotlib/matplotlib_writer.py
@@ -65,6 +65,16 @@ class MatplotlibWriter(AbstractVersionedDataSet):
         >>> plt.close()
         >>> single_plot_writer.save(plt)
         >>>
+        >>> # MatplotlibWriter can output other formats as well, such as PDF files. 
+        >>> # For this, we need to specify the format:
+        >>> plt.plot([1, 2, 3], [4, 5, 6])
+        >>> single_plot_writer = MatplotlibWriter(
+        >>>     filepath="matplot_lib_single_plot.pdf",
+        >>>     save_args={"format": "pdf"},
+        >>> )
+        >>> plt.close()
+        >>> single_plot_writer.save(plt)
+        >>>
         >>> # Saving dictionary of plots
         >>> plots_dict = dict()
         >>> for colour in ["blue", "green", "red"]:


### PR DESCRIPTION
## Description

matplotwriter requires explicitly setting the format as it writes to byteio. 
normally matplotlib picks this up from the filename
adding this example will help out users that have that expectation

## Checklist

- [X] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Updated the documentation to reflect the code changes
- [X] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [X] Added tests to cover my changes

## Notice

- [X] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
