### PR TITLE
Now that pip has a real dependency resolver...

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ commands:
           command: make install-pip-setuptools
       - run:
           name: Install requirements and test requirements
-          command: pip install -upgrade -r requirements.txt -r test_requirements.txt
+          command: pip install --upgrade -r requirements.txt -r test_requirements.txt
       - run:
           # Virtualenv 20.0.20 broke pre-commit, capped for now
           name: Install venv for some pre-commit hooks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,12 +32,12 @@ commands:
           name: Install pip setuptools
           command: make install-pip-setuptools
       - run:
-          name: Install requirements and test requirements
-          command: pip install --upgrade -r requirements.txt -r test_requirements.txt
-      - run:
           # Virtualenv 20.0.20 broke pre-commit, capped for now
           name: Install venv for some pre-commit hooks
           command: conda install -y "virtualenv<20.0"
+      - run:
+          name: Install requirements and test requirements
+          command: pip install --upgrade -r test_requirements.txt
       - run:
           # Since recently Spark installation for some reason does not have enough permissions to execute
           # /home/circleci/miniconda/envs/kedro_builder/lib/python3.X/site-packages/pyspark/bin/spark-class.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ commands:
           command: make install-pip-setuptools
       - run:
           name: Install requirements and test requirements
-          command: pip install -r requirements.txt -r test_requirements.txt -upgrade
+          command: pip install -upgrade -r requirements.txt -r test_requirements.txt
       - run:
           # Virtualenv 20.0.20 broke pre-commit, capped for now
           name: Install venv for some pre-commit hooks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,15 +32,12 @@ commands:
           name: Install pip setuptools
           command: make install-pip-setuptools
       - run:
-          name: Install requirements
-          command: pip install -r requirements.txt -U
+          name: Install requirements and test requirements
+          command: pip install -r requirements.txt -r test_requirements.txt -upgrade
       - run:
           # Virtualenv 20.0.20 broke pre-commit, capped for now
           name: Install venv for some pre-commit hooks
           command: conda install -y "virtualenv<20.0"
-      - run:
-          name: Install test requirements
-          command: pip install -r test_requirements.txt -U
       - run:
           # Since recently Spark installation for some reason does not have enough permissions to execute
           # /home/circleci/miniconda/envs/kedro_builder/lib/python3.X/site-packages/pyspark/bin/spark-class.


### PR DESCRIPTION
hand it all dependencies in a single command so that resolver can do its magic.

https://pypi.org/project/virtualenv is now at v20.6.0 so is the special install still needed?

## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
