### PR TITLE
Pin ipython to prevent ipykernel dependency problems

### DIFF
--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,6 +1,6 @@
 black==21.5b1
 flake8>=3.7.9, <4.0
-ipython~=7.10
+ipython~=7.0
 isort~=5.0
 jupyter~=1.0
 jupyter_client>=5.1, <7.0


### PR DESCRIPTION
## Description
I kept running into this error when I ran `kedro new` (blank template) and `kedro install`: 

![Screenshot 2021-08-27 at 10 37 52](https://user-images.githubusercontent.com/43755008/131129291-90cde94d-1055-435c-b928-fa825eba8eed.png)

The fix is pinning `ipython`.

## Development notes
- I pinned `ipython` to an earlier version, it matches the template for Spaceflights now

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
