### PR TITLE
Ignore .envrc for direnv users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,4 @@ docs/source/04_user_guide/source/.ipynb
 tests/template/fake_project/
 
 default.profraw
+.envrc

--- a/kedro/errors/__init__.py
+++ b/kedro/errors/__init__.py
@@ -1,0 +1,49 @@
+# Copyright 2021 QuantumBlack Visual Analytics Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+# NONINFRINGEMENT. IN NO EVENT WILL THE LICENSOR OR OTHER CONTRIBUTORS
+# BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF, OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# The QuantumBlack Visual Analytics Limited ("QuantumBlack") name and logo
+# (either separately or in combination, "QuantumBlack Trademarks") are
+# trademarks of QuantumBlack. The License does not grant you any right or
+# license to the QuantumBlack Trademarks. You may not use the QuantumBlack
+# Trademarks or any confusingly similar mark as a trademark for your product,
+# or use the QuantumBlack Trademarks in any other manner that might cause
+# confusion in the marketplace, including but not limited to in advertising,
+# on websites, or on software.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Expose public exceptions and warnings.
+"""
+
+
+class KedroConfigError(RuntimeError):
+    """
+    Error raised when kedro fails to startup due to configuration.
+    """
+
+
+class KedroSessionError(RuntimeError):
+    """
+    Error raised when kedro fails to create a new Session.
+    """
+
+
+class KedroRunnerError(RuntimeError):
+    """
+    Error raised when kedro runner hits a runtime error before all nodes are complete
+    """

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -40,6 +40,7 @@ from typing import Any, Dict, Iterable, Optional, Union
 import click
 
 from kedro import __version__ as kedro_version
+from kedro.errors import KedroSessionError
 from kedro.framework.context import KedroContext
 from kedro.framework.context.context import _convert_paths_to_absolute_posix
 from kedro.framework.hooks import get_hook_manager
@@ -47,7 +48,6 @@ from kedro.framework.project import settings
 from kedro.framework.session.store import BaseSessionStore
 from kedro.io.core import generate_timestamp
 from kedro.runner import AbstractRunner, SequentialRunner
-from kedro.errors import KedroSessionError
 
 _active_session = None
 

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -47,6 +47,7 @@ from kedro.framework.project import settings
 from kedro.framework.session.store import BaseSessionStore
 from kedro.io.core import generate_timestamp
 from kedro.runner import AbstractRunner, SequentialRunner
+from kedro.errors import KedroSessionError
 
 _active_session = None
 
@@ -58,14 +59,14 @@ def get_current_session(silent: bool = False) -> Optional["KedroSession"]:
         silent: Indicates to suppress the error if no active session was found.
 
     Raises:
-        RuntimeError: If no active session was found and `silent` is False.
+        KedroSessionError: If no active session was found and `silent` is False.
 
     Returns:
         KedroSession instance.
 
     """
     if not _active_session and not silent:
-        raise RuntimeError("There is no active Kedro session.")
+        raise KedroSessionError("There is no active Kedro session.")
 
     return _active_session
 
@@ -74,7 +75,7 @@ def _activate_session(session: "KedroSession", force: bool = False) -> None:
     global _active_session
 
     if _active_session and not force and session is not _active_session:
-        raise RuntimeError(
+        raise KedroSessionError(
             "Cannot activate the session as another active session already exists."
         )
 


### PR DESCRIPTION
## Description

I use a package called direnv to make sure that my virtual environment is automatically activated when I cd into a project, it would be nice if I dont have this file always siting there as a new file fearing that I might commit it accidently.

## Development notes
added one line to the projects gitignore.

## Checklist

- [ ] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
