### PR TITLE
Sphinx redirect

### DIFF
--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -49,9 +49,9 @@ mkdir docs/build/
 cp -r docs/_templates docs/conf.py docs/*.svg docs/*.json  docs/build/
 
 if [ "$action" == "linkcheck" ]; then
-  sphinx-build -c docs/ -WETan -j auto -D language=en -b linkcheck docs/build/ docs/build/html
+  sphinx-build -c docs/ -ETan -j auto -D language=en -b linkcheck docs/build/ docs/build/html
 elif [ "$action" == "docs" ]; then
-  sphinx-build -c docs/ -WETa -j auto -D language=en docs/build/ docs/build/html
+  sphinx-build -c docs/ -ETa -j auto -D language=en docs/build/ docs/build/html
 fi
 
 # Clean up build artefacts

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,6 +60,7 @@ extensions = [
     "nbsphinx",
     "recommonmark",
     "sphinx_copybutton",
+    "sphinx_reredirects",
 ]
 
 # enable autosummary plugin (table of contents for modules/classes/class
@@ -211,6 +212,15 @@ linkcheck_rate_limit_timeout = 2.0
 html_context = {
     "display_github": True,
     "github_url": "https://github.com/quantumblacklabs/kedro/tree/master/docs/source",
+}
+
+
+# sphinx-reredirects
+# redirects old page names to the latest page name so that bookmarked pages
+# still work
+
+redirects = {
+    "13_deployment/04_argo.html": "10_deployment/04_argo.html",
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,7 @@ extras_require = {
     "docs": [
         "docutils==0.16",
         "sphinx~=3.4.3",
+        "sphinx-reredirects==0.0.1",
         "sphinx_rtd_theme==0.4.1",
         "nbsphinx==0.8.1",
         "nbstripout~=0.4",


### PR DESCRIPTION
## Description

Attempt to resolve #857


## Development notes

I have installed and implemented one redirect then ran `make build-docs`.  I hosted the docs locally by running `cd docs/build/html/ && python -m http.server`.  As mentioned in the issue the redirect is unsuccessful as it is leaving part of the previous route in the url.  I am not sure if this is possible with this plugin.

## Checklist

- [ ] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
