### PR TITLE
Make `_IsSubclassValidator` work with new Dynaconf

### DIFF
--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -58,10 +58,9 @@ class _IsSubclassValidator(Validator):
         self,
         settings: Any,
         env: Optional[str] = None,
-        only: Optional[Union[str, Sequence]] = None,
-        exclude: Optional[Union[str, Sequence]] = None,
+        **kwargs: Any,
     ) -> None:
-        super()._validate_items(settings, env, only, exclude)
+        super()._validate_items(settings, env, **kwargs)
 
         default_class = self.default(settings, self)
         for name in self.names:

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -31,7 +31,7 @@ configure a Kedro project and access its settings."""
 import importlib
 import operator
 from collections.abc import MutableMapping
-from typing import Any, Dict, Optional, Sequence, Union
+from typing import Any, Dict, Optional
 from warnings import warn
 
 from dynaconf import LazySettings

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -54,8 +54,14 @@ def _get_default_class(class_import_path):
 class _IsSubclassValidator(Validator):
     """A validator to check if the supplied setting value is a subclass of the default class"""
 
-    def _validate_items(self, settings, env=None):
-        super()._validate_items(settings, env)
+    def _validate_items(
+        self,
+        settings: Any,
+        env: Optional[str] = None,
+        only: Optional[Union[str, Sequence]] = None,
+        exclude: Optional[Union[str, Sequence]] = None,
+    ) -> None:
+        super()._validate_items(settings, env, only, exclude)
 
         default_class = self.default(settings, self)
         for name in self.names:

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -54,11 +54,11 @@ def _get_default_class(class_import_path):
 class _IsSubclassValidator(Validator):
     """A validator to check if the supplied setting value is a subclass of the default class"""
 
-    def _validate_items(
+    def _validate_items(  # pylint: disable=arguments-differ; work with `dynaconf<3.1.6`
         self,
         settings: Any,
         env: Optional[str] = None,
-        **kwargs: Any,  # pylint: disable=arguments-differ; work with ``dynaconf<3.1.6``
+        **kwargs: Any,
     ) -> None:
         super()._validate_items(settings, env, **kwargs)
 

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -31,7 +31,7 @@ configure a Kedro project and access its settings."""
 import importlib
 import operator
 from collections.abc import MutableMapping
-from typing import Dict, Optional
+from typing import Any, Dict, Optional, Sequence, Union
 from warnings import warn
 
 from dynaconf import LazySettings

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -58,7 +58,7 @@ class _IsSubclassValidator(Validator):
         self,
         settings: Any,
         env: Optional[str] = None,
-        **kwargs: Any,
+        **kwargs: Any,  # pylint: disable=arguments-differ; work with ``dynaconf<3.1.6``
     ) -> None:
         super()._validate_items(settings, env, **kwargs)
 

--- a/tests/framework/session/conftest.py
+++ b/tests/framework/session/conftest.py
@@ -479,4 +479,7 @@ def mock_import(mocker):
             lambda x: settings_module if x == settings_module_name else mocker.DEFAULT
         ),
     )
-    mocker.patch("dynaconf.utils.files.find_file", return_value="")
+    mocker.patch(
+        "dynaconf.base.Settings.find_file",
+        side_effect=(lambda x: "" if settings_module_name in x else mocker.DEFAULT),
+    )

--- a/tests/framework/session/conftest.py
+++ b/tests/framework/session/conftest.py
@@ -468,7 +468,7 @@ def mock_import(mocker):
     # importing it. settings.py does not actually exists as part of this test suite,
     # so its import is mocked.
     settings_module_name = f"{MOCK_PACKAGE_NAME}.settings"
-    settings_module_location = f"src/{MOCK_PACKAGE_NAME}/settings.py"
+    settings_module_location = Path(f"src/{MOCK_PACKAGE_NAME}/settings.py").resolve()
     settings_module = module_from_spec(
         spec_from_file_location(settings_module_name, settings_module_location)
     )

--- a/tests/framework/session/conftest.py
+++ b/tests/framework/session/conftest.py
@@ -470,5 +470,5 @@ def mock_import(mocker):
     mocker.patch(
         "importlib.import_module",
         wraps=importlib.import_module,
-        side_effect=(lambda x: None if x == settings_module else mocker.DEFAULT),
+        side_effect=(lambda x: {} if x == settings_module else mocker.DEFAULT),
     )

--- a/tests/framework/session/conftest.py
+++ b/tests/framework/session/conftest.py
@@ -30,6 +30,7 @@ import logging
 from logging.handlers import QueueHandler, QueueListener
 from multiprocessing import Queue
 from pathlib import Path
+from types import ModuleType
 from typing import Any, Dict, Iterable, List, Optional
 
 import pandas as pd
@@ -470,5 +471,9 @@ def mock_import(mocker):
     mocker.patch(
         "importlib.import_module",
         wraps=importlib.import_module,
-        side_effect=(lambda x: {} if x == settings_module else mocker.DEFAULT),
+        side_effect=(
+            lambda x: ModuleType(settings_module)
+            if x == settings_module
+            else mocker.DEFAULT
+        ),
     )

--- a/tests/framework/session/conftest.py
+++ b/tests/framework/session/conftest.py
@@ -479,3 +479,4 @@ def mock_import(mocker):
             lambda x: settings_module if x == settings_module_name else mocker.DEFAULT
         ),
     )
+    mocker.patch("dynaconf.utils.files.find_file", return_value="")

--- a/tests/framework/session/conftest.py
+++ b/tests/framework/session/conftest.py
@@ -481,5 +481,9 @@ def mock_import(mocker):
     )
     mocker.patch(
         "dynaconf.base.Settings.find_file",
-        side_effect=(lambda x: "" if settings_module_name in x else mocker.DEFAULT),
+        side_effect=(
+            lambda *args, **kwargs: ""
+            if settings_module_name in args[0]
+            else mocker.DEFAULT
+        ),
     )

--- a/tests/framework/session/conftest.py
+++ b/tests/framework/session/conftest.py
@@ -468,7 +468,7 @@ def mock_import(mocker):
     # importing it. settings.py does not actually exists as part of this test suite,
     # so its import is mocked.
     settings_module_name = f"{MOCK_PACKAGE_NAME}.settings"
-    settings_module_location = Path(f"src/{MOCK_PACKAGE_NAME}/settings.py").resolve()
+    settings_module_location = f"src/{MOCK_PACKAGE_NAME}/settings.py"
     settings_module = module_from_spec(
         spec_from_file_location(settings_module_name, settings_module_location)
     )


### PR DESCRIPTION
## Description
Kedro breaks with `dynaconf~=3.1.6`, because the subclassed validator doesn't accept `only`/`exclude` arguments.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
