### PR TITLE
Overwrite dynaconf public API instead of private one.

### DIFF
--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -54,8 +54,8 @@ def _get_default_class(class_import_path):
 class _IsSubclassValidator(Validator):
     """A validator to check if the supplied setting value is a subclass of the default class"""
 
-    def validate(self, settings):
-        super().validate(settings)
+    def validate(self, settings, *args, **kwargs):
+        super().validate(settings, *args, **kwargs)
 
         default_class = self.default(settings, self)
         for name in self.names:

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -54,8 +54,8 @@ def _get_default_class(class_import_path):
 class _IsSubclassValidator(Validator):
     """A validator to check if the supplied setting value is a subclass of the default class"""
 
-    def _validate_items(self, settings, env=None):
-        super()._validate_items(settings, env)
+    def validate(self, settings):
+        super().validate(settings)
 
         default_class = self.default(settings, self)
         for name in self.names:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ anyconfig~=0.10.0
 cachetools~=4.1
 click<8.0
 cookiecutter~=1.7.0
-dynaconf~=3.1.2
+dynaconf>=3.1.2,<4.0.0
 fsspec>=2021.04, <2022.01  # Upper bound set arbitrarily, to be reassessed in early 2022
 gitpython~=3.0
 jmespath>=0.9.5, <1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ anyconfig~=0.10.0
 cachetools~=4.1
 click<8.0
 cookiecutter~=1.7.0
-dynaconf<3.1.6 # Pinned because Dynaconf broke a method signature in 3.1.6 used in Kedro
+dynaconf~=3.1.5 # Pinned because Dynaconf broke a method signature in 3.1.6 used in Kedro
 fsspec>=2021.04, <2022.01  # Upper bound set arbitrarily, to be reassessed in early 2022
 gitpython~=3.0
 jmespath>=0.9.5, <1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ anyconfig~=0.10.0
 cachetools~=4.1
 click<8.0
 cookiecutter~=1.7.0
-dynaconf~=3.1.5 # Pinned because Dynaconf broke a method signature in 3.1.6 used in Kedro
+dynaconf~=3.1.2
 fsspec>=2021.04, <2022.01  # Upper bound set arbitrarily, to be reassessed in early 2022
 gitpython~=3.0
 jmespath>=0.9.5, <1.0

--- a/tests/framework/session/conftest.py
+++ b/tests/framework/session/conftest.py
@@ -462,15 +462,8 @@ def mock_session(
 
 
 @pytest.fixture(autouse=True)
-def mock_import(mocker):
+def mock_validate_settings(mocker):
     # KedroSession eagerly validates that a project's settings.py is correct by
-    # importing it. settings.py does not actually exists as part of this test suite,
-    # so its import is mocked.
-    settings_module = f"{MOCK_PACKAGE_NAME}.settings"
-    mocker.patch(
-        "importlib.import_module",
-        wraps=importlib.import_module,
-        side_effect=(
-            lambda x: mocker.MagicMock() if x == settings_module else mocker.DEFAULT
-        ),
-    )
+    # importing it. settings.py does not actually exists as part of this test suite
+    # since we are testing session in isolation, so the validation is patched.
+    mocker.patch("kedro.framework.session.session.validate_settings")

--- a/tests/framework/session/conftest.py
+++ b/tests/framework/session/conftest.py
@@ -25,7 +25,6 @@
 #
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import importlib
 import logging
 from logging.handlers import QueueHandler, QueueListener
 from multiprocessing import Queue

--- a/tests/framework/session/conftest.py
+++ b/tests/framework/session/conftest.py
@@ -470,5 +470,7 @@ def mock_import(mocker):
     mocker.patch(
         "importlib.import_module",
         wraps=importlib.import_module,
-        side_effect=(lambda x: None if x == settings_module else mocker.DEFAULT),
+        side_effect=(
+            lambda x: mocker.MagicMock() if x == settings_module else mocker.DEFAULT
+        ),
     )


### PR DESCRIPTION
## Description

To avoid incompatibility with future changes in dynaconf private API, switching the implementation of the `IsSubclassValidator` to use their public API instead. I can't remember for the life of me why I had to use the private API before.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
