### PR TITLE
Extend PickleDataSet to accept arbitrary backends

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,13 +5,15 @@
 
 ## Bug fixes and other changes
 * Fixed an issue where `kedro new --config config.yml` was ignoring the config file when `prompts.yml` didn't exist.
+* Added support for arbitrary backends (via importable module paths) that satisfy the `pickle` interface to `PickleDataSet`
 
 ## Minor breaking changes to the API
 
 ## Upcoming deprecations for Kedro 0.18.0
 
 ## Thanks for supporting contributions
-[Deepyaman Datta](https://github.com/deepyaman)
+[Deepyaman Datta](https://github.com/deepyaman),
+[Zain Patel](https://github.com/mzjp2)
 
 # Release 0.17.5
 

--- a/kedro/extras/datasets/pickle/pickle_dataset.py
+++ b/kedro/extras/datasets/pickle/pickle_dataset.py
@@ -28,13 +28,13 @@
 
 """``PickleDataSet`` loads/saves data from/to a Pickle file using an underlying
 filesystem (e.g.: local, S3, GCS). The underlying functionality is supported by
-the ``pickle``, ``joblib``, ``dill``, and ``compress_pickle`` libraries, so it
+the specified backend library passed in (defaults to the ``pickle`` library), so it
 supports all allowed options for loading and saving pickle files.
 """
-import pickle
 from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any, Dict
+import importlib
 
 import fsspec
 
@@ -46,26 +46,11 @@ from kedro.io.core import (
     get_protocol_and_path,
 )
 
-try:
-    import joblib
-except ImportError:  # pragma: no cover
-    joblib = None
-
-try:
-    import dill
-except ImportError:  # pragma: no cover
-    dill = None
-
-try:
-    import compress_pickle
-except ImportError:  # pragma: no cover
-    compress_pickle = None
-
 
 class PickleDataSet(AbstractVersionedDataSet):
     """``PickleDataSet`` loads/saves data from/to a Pickle file using an underlying
     filesystem (e.g.: local, S3, GCS). The underlying functionality is supported by
-    the ``pickle``, ``joblib``, ``dill``, and ``compress_pickle`` libraries, so it
+    the specified backend library passed in (defaults to the ``pickle`` library), so it
     supports all allowed options for loading and saving pickle files.
 
     Example:
@@ -95,12 +80,6 @@ class PickleDataSet(AbstractVersionedDataSet):
 
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
-    BACKENDS = {
-        "pickle": pickle,
-        "joblib": joblib,
-        "dill": dill,
-        "compress_pickle": compress_pickle,
-    }
 
     # pylint: disable=too-many-arguments
     def __init__(
@@ -114,18 +93,19 @@ class PickleDataSet(AbstractVersionedDataSet):
         fs_args: Dict[str, Any] = None,
     ) -> None:
         """Creates a new instance of ``PickleDataSet`` pointing to a concrete Pickle
-        file on a specific filesystem. ``PickleDataSet`` supports four backends to
-        serialize/deserialize objects: `pickle`, `joblib`, `dill`, and `compress_pickle`.
+        file on a specific filesystem. ``PickleDataSet`` supports custom backends to
+        serialize/deserialize objects.
 
         Args:
             filepath: Filepath in POSIX format to a Pickle file prefixed with a protocol like
                 `s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used.
                 The prefix should be any protocol supported by ``fsspec``.
                 Note: `http(s)` doesn't support versioning.
-            backend: Backend to use, must be one of ['pickle', 'joblib', 'dill', 'compress_pickle'].
+            backend: Backend to use, must be an import path to a module which satisfies the
+                ``pickle`` interface. That is, contains a `load` and `dump` function.
                 Defaults to 'pickle'.
             load_args: Pickle options for loading pickle files.
-                Here you can find all available arguments for different backends:
+                You can pass in the arguments that the relevant backend load function specified accepts, e.g:
                 pickle.load: https://docs.python.org/3/library/pickle.html#pickle.load
                 joblib.load: https://joblib.readthedocs.io/en/latest/generated/joblib.load.html
                 dill.load: https://dill.readthedocs.io/en/latest/dill.html#dill._dill.load
@@ -133,7 +113,7 @@ class PickleDataSet(AbstractVersionedDataSet):
                 https://lucianopaz.github.io/compress_pickle/html/api/compress_pickle.html#compress_pickle.compress_pickle.load
                 All defaults are preserved.
             save_args: Pickle options for saving pickle files.
-                Here you can find all available arguments for different backends:
+                You can pass in the arguments that the relevant backend dump function specified accepts, e.g:
                 pickle.dump: https://docs.python.org/3/library/pickle.html#pickle.dump
                 joblib.dump: https://joblib.readthedocs.io/en/latest/generated/joblib.dump.html
                 dill.dump: https://dill.readthedocs.io/en/latest/dill.html#dill._dill.dump
@@ -155,21 +135,22 @@ class PickleDataSet(AbstractVersionedDataSet):
                 All defaults are preserved, except `mode`, which is set to `wb` when saving.
 
         Raises:
-            ValueError: If ``backend`` is not one of ['pickle', 'joblib', 'dill',
-                'compress_pickle'].
-            ImportError: If ``backend`` library could not be imported.
+            ValueError: If ``backend`` does not satisfy the `pickle` interface.
+            ImportError: If the ``backend`` module could not be imported.
         """
-        if backend not in self.BACKENDS:
-            raise ValueError(
-                f"'backend' should be one of {list(self.BACKENDS.keys())}, "
-                f"got '{backend}'."
-            )
-
-        if not self.BACKENDS[backend]:
+        try:
+            imported_backend = importlib.import_module(backend)
+        except ImportError as exc:
             raise ImportError(
-                f"Selected backend '{backend}' could not be "
-                "imported. Make sure it is installed."
-            )
+                f"Selected backend '{backend}' could not be imported. "
+                "Make sure it is installed and importable."
+            ) from exc
+
+        if not (hasattr(imported_backend, "load") and hasattr(imported_backend, "dump")):
+            raise ValueError(
+                f"Selected backend '{backend}' should satisfy the pickle interface. "
+                "Missing one of `load` and `dump` on the backend."
+                )
 
         _fs_args = deepcopy(fs_args) or {}
         _fs_open_args_load = _fs_args.pop("open_args_load", {})
@@ -190,7 +171,7 @@ class PickleDataSet(AbstractVersionedDataSet):
             glob_function=self._fs.glob,
         )
 
-        self._backend = backend
+        self._backend = imported_backend
 
         # Handle default load and save arguments
         self._load_args = deepcopy(self.DEFAULT_LOAD_ARGS)
@@ -218,16 +199,16 @@ class PickleDataSet(AbstractVersionedDataSet):
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
 
         with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
-            return self.BACKENDS[self._backend].load(
+            return self._backend.load(
                 fs_file, **self._load_args
-            )  # nosec
+            ) # nosec
 
     def _save(self, data: Any) -> None:
         save_path = get_filepath_str(self._get_save_path(), self._protocol)
 
         with self._fs.open(save_path, **self._fs_open_args_save) as fs_file:
             try:
-                self.BACKENDS[self._backend].dump(data, fs_file, **self._save_args)
+                self._backend.dump(data, fs_file, **self._save_args)
             except Exception as exc:
                 raise DataSetError(
                     f"{data.__class__} was not serialized due to: {exc}"

--- a/tests/extras/datasets/pickle/test_pickle_dataset.py
+++ b/tests/extras/datasets/pickle/test_pickle_dataset.py
@@ -163,19 +163,23 @@ class TestPickleDataSet:
         with pytest.raises(DataSetError, match=pattern):
             pickle_data_set.save(dummy_dataframe)
 
-    def test_invalid_backend(self):
+    def test_invalid_backend(self, mocker):
         pattern = (
-            r"'backend' should be one of \['pickle', 'joblib', 'dill', "
-            r"'compress_pickle'\], got 'invalid'\."
+            r"Selected backend 'invalid' should satisfy the pickle interface. "
+            r"Missing one of `load` and `dump` on the backend."
         )
+        mocker.patch("kedro.extras.datasets.pickle.pickle_dataset.importlib.import_module", return_value=object)
         with pytest.raises(ValueError, match=pattern):
             PickleDataSet(filepath="test.pkl", backend="invalid")
 
-    @pytest.mark.parametrize("backend", ["joblib", "dill", "compress_pickle"])
     def test_no_backend(self, mocker, backend):
-        mocker.patch.object(PickleDataSet, "BACKENDS", {backend: None})
-        with pytest.raises(ImportError):
-            PickleDataSet(filepath="test.pkl", backend=backend)
+        pattern = (
+            r"Selected backend 'fake.backend.does.not.exist' could not be imported. "
+            r"Make sure it is installed and importable."
+        )
+        mocker.patch("kedro.extras.datasets.pickle.pickle_dataset.importlib.import_module", side_effect=ImportError)
+        with pytest.raises(ImportError, match=pattern):
+            PickleDataSet(filepath="test.pkl", backend="fake.backend.does.not.exist")
 
 
 class TestPickleDataSetVersioned:


### PR DESCRIPTION
## Description
Implements the request in #919, along with the caveat in https://github.com/quantumblacklabs/kedro/issues/919#issuecomment-933914550

This change is backwards compatible with the existing `backend`s we have today.

## Development notes
* Turned the `backend` into a module-string that I use `importlib` to import and call the `load` and `dump` methods on for `load/save` methods respectively.
* Cleaned up the docstrings to reference this new arbitrary backend rather than the hardcoded 4, though left references to the previous 4 as "good examples" of existing backends (e.g linking to their load and dump arguments.
* Updated the tests to match the new functionality, as well as improved one of them (the `ImportError` test) to test the actual exception string. Not sure how that 100% coverage before.

Two questions:

1. I'm assuming you're happy with the caveat I mentioned, otherwise the alternatives are:
a. Instead of `backend`, use `load_method` and `dump_method` and make those import-paths to functions. This is backwards-incompatible with the way `backends` currently work now and I wouldn't recommend this.
b. Allowing the use of a special-case `load_arg` and `save_arg` titled something like `load_name` and `save_name` so that the user can specify the name of the `load ` and `dump` method on the backend, and default them to `load` and `dump` respectively. This would open support for `torch` whilst remaining backwards compatible.

I would recommend b) over a), but will leave the final decision up to you.

2. I've left `dill`, `compress_pickle` and `joblib` in the `test_requirements.txt` as well as left them inside the `test_load` test of the dataset, but perhaps a more pure test here would be:

Creating a tiny custom mocked backend during the test and passing that in (as well as testing the `load_args` and `save_args` functionality) and removing those three backends from the `test_requirements.txt`.

I felt that was a tad overkill here (and I'm lazy), but again -- if you feel this is the way to go, happy to implement this.

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change and added my name to the list of supporting contributions in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [x] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
