### PR TITLE
[KED-2931] Deprecate transformers

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,7 +32,8 @@
 ## Minor breaking changes to the API
 
 ## Upcoming deprecations for Kedro 0.18.0
-* `kedro.extras.decorators` is being deprecated in favour of Hooks.
+* `kedro.extras.decorators` and `kedro.pipeline.decorators` are being deprecated in favour of Hooks.
+* `kedro.extras.transformers` and `kedro.io.transformers` are being deprecated in favour of Hooks.
 
 ## Thanks for supporting contributions
 [Deepyaman Datta](https://github.com/deepyaman),

--- a/kedro/extras/transformers/__init__.py
+++ b/kedro/extras/transformers/__init__.py
@@ -1,6 +1,15 @@
 """``kedro.extras.transformers`` is the home of Kedro's dataset transformers."""
+import warnings
 
 from .memory_profiler import ProfileMemoryTransformer
 from .time_profiler import ProfileTimeTransformer
 
 __all__ = ["ProfileMemoryTransformer", "ProfileTimeTransformer"]
+
+warnings.simplefilter("default", DeprecationWarning)
+
+warnings.warn(
+    "Support for transformers will be deprecated in Kedro 0.18.0. "
+    "Please use Hooks `before_dataset_loaded` or `after_dataset_loaded` instead.",
+    DeprecationWarning,
+)

--- a/kedro/extras/transformers/__init__.py
+++ b/kedro/extras/transformers/__init__.py
@@ -10,6 +10,7 @@ warnings.simplefilter("default", DeprecationWarning)
 
 warnings.warn(
     "Support for transformers will be deprecated in Kedro 0.18.0. "
-    "Please use Hooks `before_dataset_loaded` or `after_dataset_loaded` instead.",
+    "Please use Hooks `before_dataset_loaded`/`after_dataset_loaded` or "
+    "`before_dataset_save`/`after_dataset_saved` instead.",
     DeprecationWarning,
 )

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -186,6 +186,14 @@ class DataCatalog:
         self.datasets = _FrozenDatasets(self._data_sets)
         self.layers = layers
 
+        if transformers or default_transformers:
+            warnings.warn(
+                "The transformer API will be deprecated in Kedro 0.18.0."
+                "Please use Dataset Hooks to customise the load and save methods."
+                "For more information, please visit"
+                "https://kedro.readthedocs.io/en/stable/07_extend_kedro/02_hooks.html",
+                DeprecationWarning,
+            )
         self._transformers = {k: list(v) for k, v in (transformers or {}).items()}
         self._default_transformers = list(default_transformers or [])
         self._check_and_normalize_transformers()

--- a/kedro/io/transformers.py
+++ b/kedro/io/transformers.py
@@ -2,16 +2,7 @@
 ``DataCatalog``.
 """
 import abc
-import warnings
 from typing import Any, Callable
-
-warnings.simplefilter("default", DeprecationWarning)
-
-warnings.warn(
-    "Support for transformers will be deprecated in Kedro 0.18.0. "
-    "Please use Hooks `before_dataset_loaded` or `after_dataset_loaded` instead.",
-    DeprecationWarning,
-)
 
 
 class AbstractTransformer(abc.ABC):

--- a/kedro/io/transformers.py
+++ b/kedro/io/transformers.py
@@ -2,7 +2,16 @@
 ``DataCatalog``.
 """
 import abc
+import warnings
 from typing import Any, Callable
+
+warnings.simplefilter("default", DeprecationWarning)
+
+warnings.warn(
+    "Support for transformers will be deprecated in Kedro 0.18.0. "
+    "Please use Hooks `before_dataset_loaded` or `after_dataset_loaded` instead.",
+    DeprecationWarning,
+)
 
 
 class AbstractTransformer(abc.ABC):


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
In preparation for 0.18.0, we're deprecating & removing all remaining transformers API.
`DataCatalog.add_transformer()` was already deprecated actually, but I added a warning in the constructor. 

## Development notes
<!-- What have you changed, and how has this been tested? -->
Didn't add a `DeprecationWarning` to `kedro.io.transformers` [in the end](https://github.com/quantumblacklabs/kedro/pull/1020/commits/b929534a9a9dfb9cded2d1d281ca0221df15841a) because it's imported at top-level `__init__.py` and users wouldn't be able to turn off the annoying warning even if they don't use transformers (i.e. it's done when importing `DataCatalog` or `MemoryDataSet`).

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
