### PR TITLE
Add new logging config for CLI hooks manager

### DIFF
--- a/kedro/config/logging.yml
+++ b/kedro/config/logging.yml
@@ -37,6 +37,11 @@ loggers:
         handlers: [console]
         propagate: no
 
+    kedro.framework.cli.hooks.manager:
+        level: INFO
+        handlers: [console]
+        propagate: no
+
 root:
     level: INFO
     handlers: [console, info_file_handler, error_file_handler]

--- a/tests/framework/cli/test_cli_hooks.py
+++ b/tests/framework/cli/test_cli_hooks.py
@@ -80,6 +80,10 @@ class TestKedroCLIHooks:
         fake_metadata,
         fake_plugin_distribution,
     ):
+        # Workaround to ensure that the log messages are picked up by caplog.
+        # https://github.com/pytest-dev/pytest/issues/3697
+        logging.getLogger("kedro.framework.cli.hooks.manager").propagate = True
+
         Module = namedtuple("Module", ["cli"])
         mocker.patch(
             "kedro.framework.cli.cli.importlib.import_module",


### PR DESCRIPTION
## Description
In #1024, someone thought it was a good idea to tidy up the loggers a bit. Unfortunately, what said person didn't realise is that this resulted in an incredibly annoying message every time you execute a `kedro` command outside a project...
![image](https://user-images.githubusercontent.com/49395058/142851965-263dfd53-eb8e-4f82-8391-d3498b21f217.png)

The reason for this is that the CLI hooks manager was trying to write to a file `logs/info.log`, which didn't exist. Actually if we're not in a kedro project we shouldn't be trying to log messages to a file at all because that would be really annoying. I've added a special logging handler for this case which means that the message will only be shown on the console and not written to any file.

The other instances where I had changed `logging.info` to the "correct" kedro logger were in:
* `_register_hooks_setuptools`
* `Session.run`
* `DataCatalog.list`

These are all ok because they're only ever called inside a kedro project, when we _do_ want the info.log file.

## Checklist

- [ ] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes
