### PR TITLE
[KED-2946] Deprecate `DataCatalogWithDefault`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -37,6 +37,7 @@
 * `kedro.extras.decorators` and `kedro.pipeline.decorators` are being deprecated in favour of Hooks.
 * `kedro.extras.transformers` and `kedro.io.transformers` are being deprecated in favour of Hooks.
 * The `--parallel` flag on `kedro run` is being removed in favour of `--runner=ParallelRunner`. The `-p` flag will change to be an alias for `--pipeline`.
+* `kedro.io.DataCatalogWithDefault` is being deprecated, to be removed entirely in 0.18.0.
 
 ## Thanks for supporting contributions
 [Deepyaman Datta](https://github.com/deepyaman),

--- a/kedro/io/data_catalog_with_default.py
+++ b/kedro/io/data_catalog_with_default.py
@@ -1,6 +1,7 @@
 """A ``DataCatalog`` with a default ``DataSet`` implementation for any data set
 which is not registered in the catalog.
 """
+import warnings
 from typing import Any, Callable, Dict, Optional
 
 from kedro.io.core import AbstractDataSet
@@ -19,7 +20,8 @@ class DataCatalogWithDefault(DataCatalog):
         default: Callable[[str], AbstractDataSet] = None,
         remember: bool = False,
     ):
-        """A ``DataCatalog`` with a default ``DataSet`` implementation for any
+        """``DataCatalogWithDefault`` is deprecated and will be removed in Kedro 0.18.0.
+        A ``DataCatalog`` with a default ``DataSet`` implementation for any
         data set which is not registered in the catalog.
 
         Args:
@@ -54,6 +56,13 @@ class DataCatalogWithDefault(DataCatalog):
             >>> df = io.load("cars.csv")
         """
         super().__init__(data_sets)
+
+        warnings.warn(
+            "`DataCatalogWithDefault` is now deprecated and will be removed in Kedro 0.18.0."
+            "For more information, please visit "
+            "https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md",
+            DeprecationWarning,
+        )
 
         if not callable(default):
             raise TypeError(


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
The class is not used anywhere and is also not been kept up to date with changes in the `DataCatalog`.
To be removed as dead code / tech debt.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes
