### PR TITLE
[KED-2565] Deprecate `register_catalog` and `register_config_loader` hooks

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,6 +39,7 @@
 * `kedro.extras.transformers` and `kedro.io.transformers` are being deprecated in favour of Hooks.
 * The `--parallel` flag on `kedro run` is being removed in favour of `--runner=ParallelRunner`. The `-p` flag will change to be an alias for `--pipeline`.
 * `kedro.io.DataCatalogWithDefault` is being deprecated, to be removed entirely in 0.18.0.
+* The registration hooks `register_config_loader` and `register_catalog` are being deprecated.
 
 ## Thanks for supporting contributions
 [Deepyaman Datta](https://github.com/deepyaman),

--- a/kedro/framework/hooks/specs.py
+++ b/kedro/framework/hooks/specs.py
@@ -301,7 +301,12 @@ class RegistrationSpecs:
         """
         pass
 
-    @hook_spec(firstresult=True)
+    @hook_spec(
+        firstresult=True,
+        warn_on_impl=DeprecationWarning(
+            "The `register_config_loader` hook is deprecated and will be removed in Kedro 0.18.0."
+        ),
+    )
     def register_config_loader(
         self, conf_paths: Iterable[str], env: str, extra_params: Dict[str, Any]
     ) -> ConfigLoader:
@@ -317,7 +322,12 @@ class RegistrationSpecs:
         """
         pass
 
-    @hook_spec(firstresult=True)
+    @hook_spec(
+        firstresult=True,
+        warn_on_impl=DeprecationWarning(
+            "The `register_catalog` hook is deprecated and will be removed in Kedro 0.18.0."
+        ),
+    )
     def register_catalog(
         self,
         catalog: Optional[Dict[str, Dict[str, Any]]],


### PR DESCRIPTION
## Description
The `register_catalog` and `register_config_loader` hooks will be removed in Kedro 0.18.0. This PR adds a deprecation warning to both hooks. 

## Development notes
Originally, [we decided not to add a deprecation warning to the `register_config_loader` hook ](https://github.com/quantumblacklabs/private-kedro/pull/1090#issuecomment-833587489) because users can't get rid of it.  We're now closer to releasing `0.18.0` so these messages won't be showing much longer, but the original argument is still valid. I don't have a very strong opinion either way. For what it's worth this is what the warnings look like (first two lines after `kedro run`:

![Screenshot 2021-11-23 at 16 56 31](https://user-images.githubusercontent.com/49397448/143069830-40af1292-1612-44f6-bd30-36864f718558.png)

## Checklist

- [X] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [X] Added a description of this change in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes
