### PR TITLE
[KED-2638] Update docs to reflect rename of astro-iris

### DIFF
--- a/docs/source/02_get_started/06_starters.md
+++ b/docs/source/02_get_started/06_starters.md
@@ -46,7 +46,7 @@ kedro starter list
 
 The Kedro team maintains the following starters to bootstrap new Kedro projects:
 
-* [Alias `astro-iris`](https://github.com/quantumblacklabs/kedro-starters/tree/master/astro-iris): The [Kedro Iris dataset example project](https://kedro.readthedocs.io/en/stable/02_get_started/05_example_project.html) with a minimal setup for deploying the pipeline on Airflow with [Astronomer](https://www.astronomer.io/).
+* [Alias `astro-airflow-iris`](https://github.com/quantumblacklabs/kedro-starters/tree/master/astro-airflow-iris): The [Kedro Iris dataset example project](https://kedro.readthedocs.io/en/stable/02_get_started/05_example_project.html) with a minimal setup for deploying the pipeline on Airflow with [Astronomer](https://www.astronomer.io/).
 * [Alias `mini-kedro`](https://github.com/quantumblacklabs/kedro-starters/tree/master/mini-kedro): A minimum setup to use the traditional [Iris dataset](https://www.kaggle.com/uciml/iris) with Kedro's [`DataCatalog`](../05_data/01_data_catalog.md), which is a core component of Kedro. This starter is of use in the exploratory phase of a project. For more information, please read the [Mini-Kedro](../04_kedro_project_setup/04_mini_kedro.md) guide.
 * [Alias `pandas-iris`](https://github.com/quantumblacklabs/kedro-starters/tree/master/pandas-iris): The [Kedro Iris dataset example project](./05_example_project.md)
 * [Alias `pyspark-iris`](https://github.com/quantumblacklabs/kedro-starters/tree/master/pyspark-iris): An alternative Kedro Iris dataset example, using [PySpark](../11_tools_integration/01_pyspark.md)

--- a/docs/source/10_deployment/11_airflow_astronomer.md
+++ b/docs/source/10_deployment/11_airflow_astronomer.md
@@ -146,8 +146,8 @@ If you visit the Airflow UI, you should now see the Kedro pipeline as an Airflow
 
 ## Final thought
 
-This tutorial walks you through the manual process of deploying an existing Kedro project on Apache Airflow with Astronomer. However, if you are starting out, consider using our `astro-iris` starter which provides all the aforementioned boilerplate out of the box:
+This tutorial walks you through the manual process of deploying an existing Kedro project on Apache Airflow with Astronomer. However, if you are starting out, consider using our `astro-airflow-iris` starter which provides all the aforementioned boilerplate out of the box:
 
 ```shell
-kedro new --starter=astro-iris
+kedro new --starter=astro-airflow-iris
 ```

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -29,7 +29,7 @@ KEDRO_PATH = Path(kedro.__file__).parent
 TEMPLATE_PATH = KEDRO_PATH / "templates" / "project"
 
 _STARTER_ALIASES = {
-    "astro-iris",
+    "astro-airflow-iris",
     "mini-kedro",
     "pandas-iris",
     "pyspark",


### PR DESCRIPTION
## Description
https://github.com/quantumblacklabs/kedro-starters/pull/53

## Development notes
The `astro-iris` starter has been renamed to `astro-airflow-iris` to reflect that astro as well as airflow are used. 

## Checklist

- [X] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes
