### PR TITLE
Update logging.yml

### DIFF
--- a/kedro/config/logging.yml
+++ b/kedro/config/logging.yml
@@ -15,7 +15,7 @@ handlers:
         class: logging.handlers.RotatingFileHandler
         level: INFO
         formatter: simple
-        filename: logs/info.log
+        filename: info.log
         maxBytes: 10485760 # 10MB
         backupCount: 20
         encoding: utf8
@@ -25,7 +25,7 @@ handlers:
         class: logging.handlers.RotatingFileHandler
         level: ERROR
         formatter: simple
-        filename: logs/errors.log
+        filename: errors.log
         maxBytes: 10485760 # 10MB
         backupCount: 20
         encoding: utf8


### PR DESCRIPTION
## Description
Next part in the saga of me thinking I've improved our logging, only to realise I made it worse and now need to revert my previous changes. See #1024 #1058.

Now the problem is that if you run a kedro command outside a project and something happens to emit a log message, it will complain that the `logs` directory doesn't exist. Here's an example provoked by the log `numexpr.utils - INFO - NumExpr defaulting to 8 threads.`
![image](https://user-images.githubusercontent.com/49395058/144100280-53c07b7f-4a06-4e3e-827a-abc98964aff4.png)

Unfortunately the log handler can create a log file when it doesn't exist but can't create a directory for that file to live in (see [here](https://stackoverflow.com/questions/41764941/python-logging-create-log-if-not-exists-or-open-and-continue-logging-if-it-does#comment86437456_41765003)).

I've now put this back to how it was before, meaning that logging with work without generating more error messages but that the logs themselves are written to the wrong place (info.log rather than logs/info.log).

## Development notes
I don't intend to spend any more time on this now but just note some things here if we want to come back to it in future:
* we could make our [own logging handler](https://stackoverflow.com/questions/20666764/python-logging-how-to-ensure-logfile-directory-is-created) which creates the logs folder if required, or maybe even checks whether you're in a kedro project to see whether to save to file or not
* arguably if you're outside a project you shouldn't be making any log files at all though, i.e. we should not have `info_file_handler` or `error_file_handler`. Since currently info.log with the `numexpr` message is created as soon as you do `kedro new`, which isn't great
* the problem with removing these handlers is that even when you are in a project, they are used for logging stuff before the "correct" conf/base/logging.yml file has been loaded. Hence if they are removed then the 4 messages shown in #1024 wouldn't be saved to any file
* still worth considering whether we really want both a conf/base/logging.yml file and the kedro framework default one. Possibly one of these should be removed, which would simplify things quite a bit

<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
- [ ] Added tests to cover my changes
