### PR TITLE
Correct the new dataset example

### DIFF
--- a/docs/source/07_extend_kedro/03_custom_datasets.md
+++ b/docs/source/07_extend_kedro/03_custom_datasets.md
@@ -36,7 +36,7 @@ Here is an example skeleton for `ImageDataSet`:
 <summary><b>Click to expand</b></summary>
 
 ```python
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 import numpy as np
 
@@ -99,12 +99,10 @@ Here is the implementation of the `_load` method using `fsspec` and `Pillow` to 
 
 ```python
 from pathlib import PurePosixPath
+from typing import Any, Dict
 
-from kedro.io.core import (
-    AbstractDataSet,
-    get_filepath_str,
-    get_protocol_and_path,
-)
+from kedro.io import AbstractDataSet
+from kedro.io.core import get_filepath_str, get_protocol_and_path
 
 import fsspec
 import numpy as np
@@ -133,10 +131,18 @@ class ImageDataSet(AbstractDataSet):
             Data from the image file as a numpy array
         """
         # using get_filepath_str ensures that the protocol and path are appended correctly for different filesystems
-        load_path = get_filepath_str(self._get_load_path(), self._protocol)
+        load_path = get_filepath_str(self._filepath, self._protocol)
         with self._fs.open(load_path) as f:
             image = Image.open(f).convert("RGBA")
             return np.asarray(image)
+
+    def _save(self, data: np.ndarray) -> None:
+        """Saves image data to the specified filepath"""
+        ...
+
+    def _describe(self) -> Dict[str, Any]:
+        """Returns a dict that describes the attributes of the dataset"""
+        ...
 ```
 </details>
 
@@ -177,7 +183,7 @@ class ImageDataSet(AbstractDataSet):
     def _save(self, data: np.ndarray) -> None:
         """Saves image data to the specified filepath."""
         # using get_filepath_str ensures that the protocol and path are appended correctly for different filesystems
-        save_path = get_filepath_str(self._get_save_path(), self._protocol)
+        save_path = get_filepath_str(self._filepath, self._protocol)
         with self._fs.open(save_path, "wb") as f:
             image = Image.fromarray(data)
             image.save(f)


### PR DESCRIPTION


## Description
This commit makes sure that the examples in the _custom dataset_ documentation can run without error or exceptions.

The diff view in ../meta/images/diffs-graphic.png would also need to be updated, it is incorrect in two ways:
* _get_filepath_str()_ should be used in both __save()_ and __load()_ method even after changing to the _AbstractVersionedDataSet_ base class.
* The _AbstractDataSet_ does not have any __get_load_path()_ method in contrast to the _AbstractVersionedDataSet_.

## Development notes

The example to create a new dataset had some different issues:

* __save()_ and __describe()_ methods was missing before they were implemented which causes an exception when trying to instantiate the class, instead keep the empty definitions.
* The _AbstractDataSet_ does not have any __get_load_path()_ method in contrast to the _AbstractVersionedDataSet_.
* Adds missing imports from typing.
* Remove unused import from typing.
* Imports _AbstractDataSet_ directly from _kedro.io_ instead of _kedro.io.core_ to align it with the diff-view in the docs.

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
