### PR TITLE
Fix tests for `spark.DeltaTable` dataset

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,15 @@ executors:
   py36:
     docker:
       - image: 350138855857.dkr.ecr.eu-west-2.amazonaws.com/kedro-builder:3.6
+    resource_class: medium+
   py37:
     docker:
       - image: 350138855857.dkr.ecr.eu-west-2.amazonaws.com/kedro-builder:3.7
+    resource_class: medium+
   py38:
     docker:
       - image: 350138855857.dkr.ecr.eu-west-2.amazonaws.com/kedro-builder:3.8
+    resource_class: medium+
 
 commands:
   setup_conda:
@@ -38,6 +41,14 @@ commands:
       - run:
           name: Install requirements and test requirements
           command: pip install --upgrade -r test_requirements.txt
+      - run:
+          # this is needed to fix java cacerts so
+          # spark can automatically download packages from mvn
+          # https://stackoverflow.com/a/50103533/1684058
+          name: Fix cacerts
+          command: |
+            sudo rm /etc/ssl/certs/java/cacerts
+            sudo update-ca-certificates -f
       - run:
           # Since recently Spark installation for some reason does not have enough permissions to execute
           # /home/circleci/miniconda/envs/kedro_builder/lib/python3.X/site-packages/pyspark/bin/spark-class.
@@ -452,29 +463,29 @@ workflows:
   regular:
     jobs:
       - unit_tests_36
-#      - linters_36
-#      - e2e_tests_36
-#      - docs_36
-#      - docs_linkcheck_37
+      - linters_36
+      - e2e_tests_36
+      - docs_36
+      - docs_linkcheck_37
       - unit_tests_37
-#      - linters_37
-#      - e2e_tests_37
-#      - docs_37
+      - linters_37
+      - e2e_tests_37
+      - docs_37
       - unit_tests_38
-#      - linters_38
-#      - e2e_tests_38
-#      - pip_compile_36
-#      - pip_compile_37
-#      - pip_compile_38
-#      - win_unit_tests_36
-#      - win_unit_tests_37
-#      - win_unit_tests_38
-#      - win_pip_compile_36
-#      - win_pip_compile_37
-#      - win_pip_compile_38
-#      - win_e2e_tests_36
-#      - win_e2e_tests_37
-#      - win_e2e_tests_38
+      - linters_38
+      - e2e_tests_38
+      - pip_compile_36
+      - pip_compile_37
+      - pip_compile_38
+      - win_unit_tests_36
+      - win_unit_tests_37
+      - win_unit_tests_38
+      - win_pip_compile_36
+      - win_pip_compile_37
+      - win_pip_compile_38
+      - win_e2e_tests_36
+      - win_e2e_tests_37
+      - win_e2e_tests_38
       - run_kedro_viz:
           filters:
             branches:
@@ -483,28 +494,28 @@ workflows:
       - all_circleci_checks_succeeded:
           requires:
             - unit_tests_36
-#            - linters_36
-#            - e2e_tests_36
-#            - docs_36
+            - linters_36
+            - e2e_tests_36
+            - docs_36
             - unit_tests_37
-#            - linters_37
-#            - e2e_tests_37
-#            - docs_37
-#            - docs_linkcheck_37
+            - linters_37
+            - e2e_tests_37
+            - docs_37
+            - docs_linkcheck_37
             - unit_tests_38
-#            - linters_38
-#            - e2e_tests_38
-#            - pip_compile_36
-#            - pip_compile_37
-#            - pip_compile_38
-#            - win_pip_compile_36
-#            - win_pip_compile_37
-#            - win_pip_compile_38
-#            - win_unit_tests_36
-#            - win_unit_tests_37
+            - linters_38
+            - e2e_tests_38
+            - pip_compile_36
+            - pip_compile_37
+            - pip_compile_38
+            - win_pip_compile_36
+            - win_pip_compile_37
+            - win_pip_compile_38
+            - win_unit_tests_36
+            - win_unit_tests_37
             # Skipped due to `pywin32 is in an unsupported or invalid wheel`
             # - win_e2e_tests_36
             # Skipped due to Windows fatal exception: stack overflow
             # - win_unit_tests_38
-#            - win_e2e_tests_37
-#            - win_e2e_tests_38
+            - win_e2e_tests_37
+            - win_e2e_tests_38

--- a/kedro/extras/datasets/spark/deltatable_dataset.py
+++ b/kedro/extras/datasets/spark/deltatable_dataset.py
@@ -67,9 +67,7 @@ class DeltaTableDataSet(AbstractDataSet):
     # ``ThreadRunner`` instead
     _SINGLE_PROCESS = True
 
-    def __init__(  # pylint: disable=too-many-arguments
-        self, filepath: str, credentials: Dict[str, Any] = None
-    ) -> None:
+    def __init__(self, filepath: str, credentials: Dict[str, Any] = None) -> None:
         """Creates a new instance of ``DeltaTableDataSet``.
 
         Args:

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -10,6 +10,7 @@ dask>=2021.10.0, <2022.01; python_version > '3.6' # not directly required, pinne
 dask[complete]~=2.6; python_version == '3.6'
 delta-spark~=1.0
 dill~=0.3.1
+filelock>=3.4.0, <4.0
 gcsfs>=2021.04, <2022.01  # Upper bound set arbitrarily, to be reassessed in early 2022
 geopandas>=0.6.0, <1.0
 hdfs>=2.5.8, <3.0

--- a/tests/extras/datasets/spark/conftest.py
+++ b/tests/extras/datasets/spark/conftest.py
@@ -4,63 +4,38 @@ this directory. You don't need to import the fixtures as pytest will
 discover them automatically. More info here:
 https://docs.pytest.org/en/latest/fixture.html
 """
-import gc
-from subprocess import Popen
-
 import pytest
 from delta import configure_spark_with_delta_pip
+from filelock import FileLock
 
 try:
-    from pyspark import SparkContext
     from pyspark.sql import SparkSession
 except ImportError:  # pragma: no cover
     pass  # this is only for test discovery to succeed on Python 3.8
 
-the_real_getOrCreate = None
 
-
-class UseTheSparkSessionFixtureOrMock:  # pylint: disable=too-few-public-methods
-    pass
-
-
-# prevent using spark without going through the spark_session fixture
-@pytest.fixture(scope="session", autouse=True)
-def replace_spark_default_getorcreate():
-    global the_real_getOrCreate  # pylint: disable=global-statement
-    the_real_getOrCreate = SparkSession.builder.getOrCreate
-    SparkSession.builder.getOrCreate = UseTheSparkSessionFixtureOrMock
-    return the_real_getOrCreate
-
-
-# clean up pyspark after the test module finishes
-@pytest.fixture(scope="module")
-def spark_session():  # SKIP_IF_NO_SPARK
-    SparkSession.builder.getOrCreate = the_real_getOrCreate
-    builder = (
+def _setup_spark_session():
+    return configure_spark_with_delta_pip(
         SparkSession.builder.appName("MyApp")
+        .master("local[*]")
         .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
         .config(
             "spark.sql.catalog.spark_catalog",
             "org.apache.spark.sql.delta.catalog.DeltaCatalog",
         )
-    )
+    ).getOrCreate()
 
-    spark = configure_spark_with_delta_pip(builder).getOrCreate()
-    # spark = SparkSession.builder.getOrCreate()
+
+@pytest.fixture(scope="module", autouse=True)
+def spark_session(tmp_path_factory):  # SKIP_IF_NO_SPARK
+    # When running these spark tests with pytest-xdist, we need to make sure
+    # that the spark session setup on each test process don't interfere with each other.
+    # Therefore, we block the process during the spark session setup.
+    # Locking procedure comes from pytest-xdist's own recommendation:
+    # https://github.com/pytest-dev/pytest-xdist#making-session-scoped-fixtures-execute-only-once
+    root_tmp_dir = tmp_path_factory.getbasetemp().parent
+    lock = root_tmp_dir / "semaphore.lock"
+    with FileLock(lock):  # pylint: disable=abstract-class-instantiated
+        spark = _setup_spark_session()
     yield spark
     spark.stop()
-    SparkSession.builder.getOrCreate = UseTheSparkSessionFixtureOrMock
-
-    # remove the cached JVM vars
-    SparkContext._jvm = None  # pylint: disable=protected-access
-    SparkContext._gateway = None  # pylint: disable=protected-access
-
-    # py4j doesn't shutdown properly so kill the actual JVM process
-    for obj in gc.get_objects():
-        try:
-            if isinstance(obj, Popen) and "pyspark" in obj.args[0]:
-                obj.terminate()
-        except ReferenceError:  # pragma: no cover
-            # gc.get_objects may return dead weak proxy objects that will raise
-            # ReferenceError when you isinstance them
-            pass

--- a/tests/extras/datasets/spark/test_deltatable_dataset.py
+++ b/tests/extras/datasets/spark/test_deltatable_dataset.py
@@ -1,9 +1,5 @@
-import gc
-
 import pytest
-from delta import DeltaTable, configure_spark_with_delta_pip
-from psutil import Popen
-from pyspark import SparkContext
+from delta import DeltaTable
 from pyspark.sql import SparkSession
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 from pyspark.sql.utils import AnalysisException
@@ -12,58 +8,6 @@ from kedro.extras.datasets.spark import DeltaTableDataSet, SparkDataSet
 from kedro.io import DataCatalog, DataSetError
 from kedro.pipeline import Pipeline, node
 from kedro.runner import ParallelRunner
-from tests.extras.datasets.spark.conftest import UseTheSparkSessionFixtureOrMock
-
-
-# clean up pyspark after the test module finishes
-# @pytest.fixture(scope="module", autouse=True)
-# def delta_spark_session(replace_spark_default_getorcreate):
-#     SparkSession.builder.getOrCreate = replace_spark_default_getorcreate
-#
-#     try:
-#         # As recommended in https://docs.delta.io/latest/quick-start.html#python
-#         builder = (
-#             SparkSession.builder.appName("MyApp")
-#             .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
-#             .config(
-#                 "spark.sql.catalog.spark_catalog",
-#                 "org.apache.spark.sql.delta.catalog.DeltaCatalog",
-#             )
-#         )
-#
-#         spark = configure_spark_with_delta_pip(builder).getOrCreate()
-#
-#         yield spark
-#
-#         # This fixture should be a dependency of other fixtures dealing with spark delta data
-#         # in this module so that it always exits last and stops the spark session
-#         # after tests are finished.
-#         spark.stop()
-#     except PermissionError:  # pragma: no cover
-#         # On Windows machine TemporaryDirectory can't be removed because some
-#         # files are still used by Java process.
-#         pass
-#
-#     SparkSession.builder.getOrCreate = UseTheSparkSessionFixtureOrMock
-#
-#     # remove the cached JVM vars
-#     SparkContext._jvm = None  # pylint: disable=protected-access
-#     SparkContext._gateway = None  # pylint: disable=protected-access
-#
-#     # py4j doesn't shutdown properly so kill the actual JVM process
-#     for obj in gc.get_objects():
-#         try:
-#             if isinstance(obj, Popen) and "pyspark" in obj.args[0]:
-#                 obj.terminate()  # pragma: no cover
-#         except ReferenceError:  # pragma: no cover
-#             # gc.get_objects may return dead weak proxy objects that will raise
-#             # ReferenceError when you isinstance them
-#             pass
-
-@pytest.fixture(autouse=True)
-def spark_session_autouse(spark_session):
-    # all the tests in this file require Spark
-    return spark_session
 
 
 @pytest.fixture

--- a/tests/extras/datasets/spark/test_spark_dataset.py
+++ b/tests/extras/datasets/spark/test_spark_dataset.py
@@ -51,12 +51,6 @@ HDFS_FOLDER_STRUCTURE = [
 ]
 
 
-@pytest.fixture(autouse=True)
-def spark_session_autouse(spark_session):
-    # all the tests in this file require Spark
-    return spark_session
-
-
 @pytest.fixture
 def sample_pandas_df() -> pd.DataFrame:
     return pd.DataFrame(

--- a/tests/extras/datasets/spark/test_spark_hive_dataset.py
+++ b/tests/extras/datasets/spark/test_spark_hive_dataset.py
@@ -10,15 +10,12 @@ from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
 from kedro.extras.datasets.spark import SparkHiveDataSet
 from kedro.io import DataSetError
-from tests.extras.datasets.spark.conftest import UseTheSparkSessionFixtureOrMock
 
 TESTSPARKDIR = "test_spark_dir"
 
 
-# clean up pyspark after the test module finishes
 @pytest.fixture(scope="module")
-def spark_hive_session(replace_spark_default_getorcreate):
-    SparkSession.builder.getOrCreate = replace_spark_default_getorcreate
+def spark_session():
     try:
         with TemporaryDirectory(TESTSPARKDIR) as tmpdir:
             spark = (
@@ -48,8 +45,6 @@ def spark_hive_session(replace_spark_default_getorcreate):
         # files are still used by Java process.
         pass
 
-    SparkSession.builder.getOrCreate = UseTheSparkSessionFixtureOrMock
-
     # remove the cached JVM vars
     SparkContext._jvm = None  # pylint: disable=protected-access
     SparkContext._gateway = None  # pylint: disable=protected-access
@@ -66,7 +61,7 @@ def spark_hive_session(replace_spark_default_getorcreate):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def spark_test_databases(spark_hive_session):
+def spark_test_databases(spark_session):
     """Setup spark test databases for all tests in this module."""
     dataset = _generate_spark_df_one()
     dataset.createOrReplaceTempView("tmp")
@@ -74,15 +69,15 @@ def spark_test_databases(spark_hive_session):
 
     # Setup the databases and test table before testing
     for database in databases:
-        spark_hive_session.sql(f"create database {database}")
-    spark_hive_session.sql("use default_1")
-    spark_hive_session.sql("create table table_1 as select * from tmp")
+        spark_session.sql(f"create database {database}")
+    spark_session.sql("use default_1")
+    spark_session.sql("create table table_1 as select * from tmp")
 
-    yield spark_hive_session
+    yield spark_session
 
     # Drop the databases after testing
     for database in databases:
-        spark_hive_session.sql(f"drop database {database} cascade")
+        spark_session.sql(f"drop database {database} cascade")
 
 
 def assert_df_equal(expected, result):
@@ -150,8 +145,8 @@ class TestSparkHiveDataSet:
         )
         assert_df_equal(_generate_spark_df_one(), dataset.load())
 
-    def test_overwrite_empty_table(self, spark_hive_session):
-        spark_hive_session.sql(
+    def test_overwrite_empty_table(self, spark_session):
+        spark_session.sql(
             "create table default_1.test_overwrite_empty_table (name string, age integer)"
         ).take(1)
         dataset = SparkHiveDataSet(
@@ -162,8 +157,8 @@ class TestSparkHiveDataSet:
         dataset.save(_generate_spark_df_one())
         assert_df_equal(dataset.load(), _generate_spark_df_one())
 
-    def test_overwrite_not_empty_table(self, spark_hive_session):
-        spark_hive_session.sql(
+    def test_overwrite_not_empty_table(self, spark_session):
+        spark_session.sql(
             "create table default_1.test_overwrite_full_table (name string, age integer)"
         ).take(1)
         dataset = SparkHiveDataSet(
@@ -175,8 +170,8 @@ class TestSparkHiveDataSet:
         dataset.save(_generate_spark_df_one())
         assert_df_equal(dataset.load(), _generate_spark_df_one())
 
-    def test_insert_not_empty_table(self, spark_hive_session):
-        spark_hive_session.sql(
+    def test_insert_not_empty_table(self, spark_session):
+        spark_session.sql(
             "create table default_1.test_insert_not_empty_table (name string, age integer)"
         ).take(1)
         dataset = SparkHiveDataSet(
@@ -197,8 +192,8 @@ class TestSparkHiveDataSet:
         ):
             SparkHiveDataSet(database="default_1", table="table_1", write_mode="upsert")
 
-    def test_upsert_empty_table(self, spark_hive_session):
-        spark_hive_session.sql(
+    def test_upsert_empty_table(self, spark_session):
+        spark_session.sql(
             "create table default_1.test_upsert_empty_table (name string, age integer)"
         ).take(1)
         dataset = SparkHiveDataSet(
@@ -212,8 +207,8 @@ class TestSparkHiveDataSet:
             dataset.load().sort("name"), _generate_spark_df_one().sort("name")
         )
 
-    def test_upsert_not_empty_table(self, spark_hive_session):
-        spark_hive_session.sql(
+    def test_upsert_not_empty_table(self, spark_session):
+        spark_session.sql(
             "create table default_1.test_upsert_not_empty_table (name string, age integer)"
         ).take(1)
         dataset = SparkHiveDataSet(
@@ -257,8 +252,8 @@ class TestSparkHiveDataSet:
                 table_pk=["name"],
             )
 
-    def test_invalid_schema_insert(self, spark_hive_session):
-        spark_hive_session.sql(
+    def test_invalid_schema_insert(self, spark_session):
+        spark_session.sql(
             "create table default_1.test_invalid_schema_insert "
             "(name string, additional_column_on_hive integer)"
         ).take(1)


### PR DESCRIPTION
## Description

This PR fixes the failing tests for #964. It has been very tricky to debug, so I created this PR using `feature/databricks-deltatable-dataset` as base.

## Development notes

Below is the (wild) journey I took to get to the bottom of this one.

### 🧽   Cleanup the Spark test setup

The current Spark test setup is bloated and very hard to follow with too many indirections. To be completely honest, I don't think I fully understand the whole `the_real_getOrCreate` and `UseTheSparkSessionFixtureOrMock` business. It causes a lot of issues when trying to decipher what actually was breaking, so I removed them all.  Now the setup is dead simple:

* All spark tests have an autoused `spark_session` fixture by default provided in conftest.
* Tests that need specialised session, e.g. hive, can override this fixture by providing a fixture of the same name in its test module.
* No need for all the gc cleanup, JVM caches, etc. anymore.
 
Now it's all idiomatic pytest and just works.

### 🦠   First bug: broken `cacerts`

I think we were misguided by the CI logs. What we saw were truncated and only showed a rather unhelpful

```python
Exception: Java gateway process exited before sending its port number
```

Upon inspecting the full [logs](https://circleci.com/api/v1.1/project/github/quantumblacklabs/kedro/69832/output/110/0?file=true&allocation-id=61a8e1d7010e1b64d5ab7bda-0-build%2F5441F6DA) of the original failure, I found the real error log from the JVM:

```
---------------------------- Captured stderr setup -----------------------------
Ivy Default Cache set to: /home/circleci/.ivy2/cache
The jars for the packages stored in: /home/circleci/.ivy2/jars
io.delta#delta-core_2.12 added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent-70a12613-636b-4941-bbe5-07e47b89107e;1.0
	confs: [default]
:: resolution report :: resolve 604ms :: artifacts dl 0ms
	:: modules in use:
	---------------------------------------------------------------------
	|                  |            modules            ||   artifacts   |
	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
	---------------------------------------------------------------------
	|      default     |   1   |   0   |   0   |   0   ||   0   |   0   |
	---------------------------------------------------------------------

:: problems summary ::
:::: WARNINGS
		module not found: io.delta#delta-core_2.12;1.0.0

	==== local-m2-cache: tried

	  file:/home/circleci/.m2/repository/io/delta/delta-core_2.12/1.0.0/delta-core_2.12-1.0.0.pom

	  -- artifact io.delta#delta-core_2.12;1.0.0!delta-core_2.12.jar:

	  file:/home/circleci/.m2/repository/io/delta/delta-core_2.12/1.0.0/delta-core_2.12-1.0.0.jar

	==== local-ivy-cache: tried

	  /home/circleci/.ivy2/local/io.delta/delta-core_2.12/1.0.0/ivys/ivy.xml

	  -- artifact io.delta#delta-core_2.12;1.0.0!delta-core_2.12.jar:

	  /home/circleci/.ivy2/local/io.delta/delta-core_2.12/1.0.0/jars/delta-core_2.12.jar

	==== central: tried

	  https://repo1.maven.org/maven2/io/delta/delta-core_2.12/1.0.0/delta-core_2.12-1.0.0.pom

	  -- artifact io.delta#delta-core_2.12;1.0.0!delta-core_2.12.jar:

	  https://repo1.maven.org/maven2/io/delta/delta-core_2.12/1.0.0/delta-core_2.12-1.0.0.jar

	==== spark-packages: tried

	  https://repos.spark-packages.org/io/delta/delta-core_2.12/1.0.0/delta-core_2.12-1.0.0.pom

	  -- artifact io.delta#delta-core_2.12;1.0.0!delta-core_2.12.jar:

	  https://repos.spark-packages.org/io/delta/delta-core_2.12/1.0.0/delta-core_2.12-1.0.0.jar

		::::::::::::::::::::::::::::::::::::::::::::::

		::          UNRESOLVED DEPENDENCIES         ::

		::::::::::::::::::::::::::::::::::::::::::::::

		:: io.delta#delta-core_2.12;1.0.0: not found

		::::::::::::::::::::::::::::::::::::::::::::::


:::: ERRORS
	Server access error at url https://repo1.maven.org/maven2/io/delta/delta-core_2.12/1.0.0/delta-core_2.12-1.0.0.pom (javax.net.ssl.SSLException: Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty)

	Server access error at url https://repo1.maven.org/maven2/io/delta/delta-core_2.12/1.0.0/delta-core_2.12-1.0.0.jar (javax.net.ssl.SSLException: Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty)

	Server access error at url https://repos.spark-packages.org/io/delta/delta-core_2.12/1.0.0/delta-core_2.12-1.0.0.pom (javax.net.ssl.SSLException: Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty)

	Server access error at url https://repos.spark-packages.org/io/delta/delta-core_2.12/1.0.0/delta-core_2.12-1.0.0.jar (javax.net.ssl.SSLException: Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty)
```

It says it can't resolved delta core JAR because of an SSL error: 

```
javax.net.ssl.SSLException: Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty
```

A quick Google search led me to SO and finally the fix:

```
sudo rm /etc/ssl/certs/java/cacerts
sudo update-ca-certificates -f
```

We should do this when we build `kedro-builder` image, but running it as part of a CI run works too for now.

### 🦠   Second bug: sbt (ivy2) and pytest-xdist's multi-processing don't nice together

This took _forever_ to find 😭  Below is an example log of the symptom:

```
:::: WARNINGS
		[FAILED     ] io.delta#delta-core_2.12;1.0.0!delta-core_2.12.jar: Downloaded file size doesn't match expected Content Length for https://repo1.maven.org/maven2/io/delta/delta-core_2.12/1.0.0/delta-core_2.12-1.0.0.jar. Please retry. (102ms)

		[FAILED     ] io.delta#delta-core_2.12;1.0.0!delta-core_2.12.jar: Downloaded file size doesn't match expected Content Length for https://repo1.maven.org/maven2/io/delta/delta-core_2.12/1.0.0/delta-core_2.12-1.0.0.jar. Please retry. (102ms)

	==== central: tried

	  https://repo1.maven.org/maven2/io/delta/delta-core_2.12/1.0.0/delta-core_2.12-1.0.0.jar

		[FAILED     ] org.antlr#antlr4;4.7!antlr4.jar: Downloaded file size doesn't match expected Content Length for https://repo1.maven.org/maven2/org/antlr/antlr4/4.7/antlr4-4.7.jar. Please retry. (48ms)

		[FAILED     ] org.antlr#antlr4;4.7!antlr4.jar: Downloaded file size doesn't match expected Content Length for https://repo1.maven.org/maven2/org/antlr/antlr4/4.7/antlr4-4.7.jar. Please retry. (48ms)

	==== central: tried

	  https://repo1.maven.org/maven2/org/antlr/antlr4/4.7/antlr4-4.7.jar

		[FAILED     ] org.antlr#ST4;4.0.8!ST4.jar: Downloaded file size doesn't match expected Content Length for https://repo1.maven.org/maven2/org/antlr/ST4/4.0.8/ST4-4.0.8.jar. Please retry. (12ms)

		[FAILED     ] org.antlr#ST4;4.0.8!ST4.jar: Downloaded file size doesn't match expected Content Length for https://repo1.maven.org/maven2/org/antlr/ST4/4.0.8/ST4-4.0.8.jar. Please retry. (12ms)

	==== central: tried

	  https://repo1.maven.org/maven2/org/antlr/ST4/4.0.8/ST4-4.0.8.jar

		::::::::::::::::::::::::::::::::::::::::::::::

		::              FAILED DOWNLOADS            ::

		:: ^ see resolution messages for details  ^ ::

		::::::::::::::::::::::::::::::::::::::::::::::

		:: io.delta#delta-core_2.12;1.0.0!delta-core_2.12.jar

		:: org.antlr#antlr4;4.7!antlr4.jar

		:: org.antlr#ST4;4.0.8!ST4.jar

		::::::::::::::::::::::::::::::::::::::::::::::
``` 

At first glance, it looks similar to the first problem, but it's not. It's a failed download, instead of an unresolved dependency. It says it can't download `org.antlr#antlr4;4.7!antlr4.jar` from any of the official repositories, i.e. maven, spark-apckages, etc., which makes no sense, because trying any of the link by itself, e.g. https://repo1.maven.org/maven2/org/antlr/antlr4/4.7/antlr4-4.7.jar, works just fine.

So what's going on here? I have a hunch after reading the line `Downloaded file size doesn't match expected Content Length` -- maybe two processes were trying to download these files concurrently and they interfere with each other, e.g. they all download to the same location and override each other's result. Not sure if that's actually the problem, but the hunch was correct. Running tests sequentially work. The error above only appears when running tests with pytest-xdist using more than 1 process.

The solution I implemented, which is adapted from pytest-xdist's own recommendation, is to just block all processes when a process is creating the spark session using a file lock. Works like a charm ✨ 🎩

### 💣.  Icing on the cake: OOM 

Just when I thought fixing the previous two problems were enough, [another cryptic error message](https://app.circleci.com/pipelines/github/quantumblacklabs/kedro/3668/workflows/4be1f64a-77a2-4650-9de0-c6a05e4b290c/jobs/70108) appeared:

```python
Traceback (most recent call last):
  File "/home/circleci/miniconda/envs/kedro_builder/lib/python3.8/site-packages/py4j/java_gateway.py", line 1207, in send_command
    raise Py4JNetworkError("Answer from Java side is empty")
py4j.protocol.Py4JNetworkError: Answer from Java side is empty
```

Fortunately, there is more in the error log:

```
self = <multiprocessing.popen_fork.Popen object at 0x7fb558b74b50>
process_obj = <ForkProcess name='ParallelRunnerManager-1' parent=2669 initial>

    def _launch(self, process_obj):
        code = 1
        parent_r, child_w = os.pipe()
        child_r, parent_w = os.pipe()
>       self.pid = os.fork()
E       OSError: [Errno 12] Cannot allocate memory
```

Right, it's an OOM (out of memory). This is where CircleCI's new Resource tab comes in very handy:

![Screenshot 2021-12-03 at 01 49 47](https://user-images.githubusercontent.com/2032984/144530956-eb72c2a6-2737-40ad-911e-e08698a85e4b.png)

We indeed maxed out on RAM, so I bumb the executors to `medium+`.

Now it's all passing 😆 

## Checklist

- [ ] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
