### PR TITLE
[FIX] Add missing comma in the APIDataSet example

### DIFF
--- a/kedro/extras/datasets/api/api_dataset.py
+++ b/kedro/extras/datasets/api/api_dataset.py
@@ -20,7 +20,7 @@ class APIDataSet(AbstractDataSet):
         >>>
         >>>
         >>> data_set = APIDataSet(
-        >>>     url="https://quickstats.nass.usda.gov"
+        >>>     url="https://quickstats.nass.usda.gov",
         >>>     params={
         >>>         "key": "SOME_TOKEN",
         >>>         "format": "JSON",


### PR DESCRIPTION
## Description
The example for `APIDataSet` misses a comma to work as described.

## Development notes
I just added the comma in the docstrings.

## Checklist

- [X] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
