### PR TITLE
[KED-2780] Decouple ParallelRunner from KedroSession

### DIFF
--- a/kedro/runner/parallel_runner.py
+++ b/kedro/runner/parallel_runner.py
@@ -270,7 +270,6 @@ class ParallelRunner(AbstractRunner):
 
         """
         # pylint: disable=import-outside-toplevel,cyclic-import
-        from kedro.framework.session.session import get_current_session
 
         nodes = pipeline.nodes
         self._validate_catalog(catalog, pipeline)
@@ -284,11 +283,7 @@ class ParallelRunner(AbstractRunner):
         done = None
         max_workers = self._get_required_workers_count(pipeline)
 
-        from kedro.framework.project import PACKAGE_NAME
-
-        session = get_current_session(silent=True)
-        # pylint: disable=protected-access
-        conf_logging = session._get_logging_config() if session else None
+        from kedro.framework.project import LOGGING, PACKAGE_NAME
 
         with ProcessPoolExecutor(max_workers=max_workers) as pool:
             while True:
@@ -303,7 +298,7 @@ class ParallelRunner(AbstractRunner):
                             self._is_async,
                             run_id,
                             package_name=PACKAGE_NAME,
-                            conf_logging=conf_logging,
+                            conf_logging=LOGGING,
                         )
                     )
                 if not futures:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,7 @@ layers = [
     "config"
 ]
 ignore_imports = [
-    "kedro.runner.parallel_runner -> kedro.framework.project",
-    "kedro.runner.parallel_runner -> kedro.framework.session.session"
+    "kedro.runner.parallel_runner -> kedro.framework.project"
 ]
 
 [[tool.importlinter.contracts]]


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
ParallelRunner currently invokes the active KedroSession (see this). This is needed because, when Windows "spawns" new processes, hooks have to be registered and the logger has to be configured anew. This doesn't affect Unix systems, which "fork" new processes inheriting from the parent.

As part of this PR, we already broke the dependency on KedroSession to fetch `package_name`. The remaining bit - and the scope of this PR - is to break the dependency on KedroSession to fetch `conf_logging`. In https://github.com/quantumblacklabs/kedro/pull/1103 we added a global variable `LOGGING` in project. Therefore as part of this PR ParallelRunner should use the global variable and remove calls/references to `session`.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
